### PR TITLE
break tests for ap3D into separate file and add test dependencies

### DIFF
--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,0 +1,74 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.5"
+manifest_format = "2.0"
+project_hash = "f060fb0ad9d81f815d92ff38b7d51773441ac9fd"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.23+4"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.10.0"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.10.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.2.1+1"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/ap3D.jl
+++ b/test/ap3D.jl
@@ -1,0 +1,46 @@
+@testset "ap3D" begin
+    rng = MersenneTwister(101) #should we switch to stableRNG for my peace of mind?
+
+    gainMat = 1.9 * ones(Float32, 2560, 2048)
+    readVarMat = 25 * ones(Float32, 2560, 2048)
+
+    n_reads = 20
+    n_diffs = n_reads - 1
+
+    flux_per_reads = 10 .^ (LinRange(log10(0.01), log10(10000), 2560))
+    dcounts = (randn(rng, (2560, 2048, n_diffs)) .* (flux_per_reads .^ 0.5)) .+
+              flux_per_reads
+
+    true_im = ones(Float32, 2560, 2048) .* flux_per_reads
+
+    outdat = zeros(Float32, (2560, 2048, n_reads))
+    outdat[begin:end, begin:end, (begin + 1):end] .+= cumsum(dcounts, dims = 3)
+    outdat .+= randn(rng, (2560, 2048, n_reads)) .* (readVarMat .^ 0.5)
+    outdat ./= gainMat
+
+    dimage, ivarimage, chisqimage = sutr_tb(outdat, gainMat, readVarMat)
+    #    dimage, ivarimage, chisqimage = dcs(outdat,gainMat,readVarMat)
+
+    flux_diffs = (dimage .- true_im)
+    zscores = flux_diffs ./ (ivarimage .^ (-0.5))
+
+    full_mean_z = mean(zscores)
+    full_std_z = std(zscores)
+    flux_mean_z = mean(zscores, dims = 2)
+    flux_std_z = std(zscores, dims = 2)
+    flux_mean = mean(dimage, dims = 2)
+    flux_diff_mean = mean(flux_diffs, dims = 2)
+    flux_err_mean = mean(ivarimage .^ (-0.5), dims = 2)
+
+    #expected outputs when n_reads=20, seed=101, extract_method=sutr_tb
+    @test isapprox(full_mean_z, -0.05, atol = 0.001)
+    @test isapprox(full_std_z, 1.0427, atol = 0.001)
+    @test isapprox(flux_mean_z[begin], -0.1298, atol = 0.06)
+    @test isapprox(flux_mean_z[end], -0.04463, atol = 0.08)
+    @test isapprox(flux_std_z[begin], 1.0104, atol = 0.01)
+    @test isapprox(flux_std_z[end], 1.03251, atol = 0.06)
+    @test isapprox(flux_mean[begin], -0.002658, atol = 0.01)
+    @test isapprox(flux_mean[end], 9998.98, atol = 3)
+    @test isapprox(flux_err_mean[begin], 0.20749, atol = 0.003)
+    @test isapprox(flux_err_mean[end], 23.57064, atol = 0.003)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,58 +1,9 @@
-using ApogeeReduction
-using Test
-using Base
-using Random
+using ApogeeReduction, Test, Random, Statistics
 
 src_dir = "../"
 include(src_dir * "src/ap3D.jl")
 
-using StatsBase
-
+# The file structure in test roughly mirrors that of src.  Each file is included below.
 @testset "ApogeeReduction.jl" begin
-    # Write your tests here.
-
-    rng = MersenneTwister(101) #should we switch to stableRNG for my peace of mind?
-
-    gainMat = 1.9 * ones(Float32, 2560, 2048)
-    readVarMat = 25 * ones(Float32, 2560, 2048)
-
-    n_reads = 20
-    n_diffs = n_reads - 1
-
-    flux_per_reads = 10 .^ (LinRange(log10(0.01), log10(10000), 2560))
-    dcounts = (randn(rng, (2560, 2048, n_diffs)) .* (flux_per_reads .^ 0.5)) .+
-              flux_per_reads
-
-    true_im = ones(Float32, 2560, 2048) .* flux_per_reads
-
-    outdat = zeros(Float32, (2560, 2048, n_reads))
-    outdat[begin:end, begin:end, (begin + 1):end] .+= cumsum(dcounts, dims = 3)
-    outdat .+= randn(rng, (2560, 2048, n_reads)) .* (readVarMat .^ 0.5)
-    outdat ./= gainMat
-
-    dimage, ivarimage, chisqimage = sutr_tb(outdat, gainMat, readVarMat)
-    #    dimage, ivarimage, chisqimage = dcs(outdat,gainMat,readVarMat)
-
-    flux_diffs = (dimage .- true_im)
-    zscores = flux_diffs ./ (ivarimage .^ (-0.5))
-
-    full_mean_z = mean(zscores)
-    full_std_z = std(zscores)
-    flux_mean_z = mean(zscores, dims = 2)
-    flux_std_z = std(zscores, dims = 2)
-    flux_mean = mean(dimage, dims = 2)
-    flux_diff_mean = mean(flux_diffs, dims = 2)
-    flux_err_mean = mean(ivarimage .^ (-0.5), dims = 2)
-
-    #expected outputs when n_reads=20, seed=101, extract_method=sutr_tb
-    @test isapprox(full_mean_z, -0.05, atol = 0.001)
-    @test isapprox(full_std_z, 1.0427, atol = 0.001)
-    @test isapprox(flux_mean_z[begin], -0.1298, atol = 0.06)
-    @test isapprox(flux_mean_z[end], -0.04463, atol = 0.08)
-    @test isapprox(flux_std_z[begin], 1.0104, atol = 0.01)
-    @test isapprox(flux_std_z[end], 1.03251, atol = 0.06)
-    @test isapprox(flux_mean[begin], -0.002658, atol = 0.01)
-    @test isapprox(flux_mean[end], 9998.98, atol = 3)
-    @test isapprox(flux_err_mean[begin], 0.20749, atol = 0.003)
-    @test isapprox(flux_err_mean[end], 23.57064, atol = 0.003)
+    include("ap3D.jl")
 end


### PR DESCRIPTION
Very basic refactor of ap3D tests.  This adds the test dependencies in to `test/Project.toml` and breaks the ap3D tests into a separate file.