### PR TITLE
parallelize trace extraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,11 @@ version = "1.0.0-DEV"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 FastRunningMedian = "3a47ddbd-112b-4cc1-b00e-3746ec434ee5"
@@ -39,10 +40,11 @@ SlackThreads = {rev = "main", url = "https://github.com/andrew-saydjari/SlackThr
 
 [compat]
 ArgParse = "1"
+CairoMakie = "0.12.16"
+ColorSchemes = "3.27.1"
 CondaPkg = "0.2"
 DataFrames = "1"
 Distributions = "0.25.113"
-Einsum = "0.4.1"
 EllipsisNotation = "1"
 FITSIO = "0.17"
 FastRunningMedian = "0.3.0"

--- a/src/cal_build/make_traces_domeflats.jl
+++ b/src/cal_build/make_traces_domeflats.jl
@@ -52,7 +52,7 @@ if parg["runlist"] != "" # only multiprocess if we have a list of exposures
 end
 
 @everywhere begin
-    using JLD2, ProgressMeter, ArgParse, Glob, StatsBase, Einsum, ParallelDataTransfer
+    using JLD2, ProgressMeter, ArgParse, Glob, StatsBase, ParallelDataTransfer
     src_dir = "../"
     include(src_dir * "/makie_plotutils.jl")
     include(src_dir * "/utils.jl")

--- a/src/cal_build/run_trace_cal.sh
+++ b/src/cal_build/run_trace_cal.sh
@@ -17,17 +17,18 @@ doutdir=$outdir
 almanac_file=${outdir}almanac/${runname}.h5
 runlist=${outdir}almanac/runlist_${runname}.jld2
 
-# set up the output directory (if does not exist)
-mkdir -p ${outdir}almanac
-
-# get the data summary file for the MJD
-almanac -v -p 12 --mjd-start $mjd_start --mjd-end $mjd_end --${tele} --output $almanac_file
-
-# get the runlist file (julia projects seem to refer to where your cmd prompt is when you call the shell. Here I imaging sitting at ApogeeReduction.jl level)
-julia +1.11.0 --project="./" src/cal_build/make_runlist_dome_flats.jl --tele $tele --almanac_file $almanac_file --output $runlist
-
-# run the reduction pipeline (all cals like dark sub/flats that would be a problem, should be post 3D->2D extraction)
-julia +1.11.0 --project="./" pipeline.jl --tele $tele --runlist $runlist --outdir $doutdir --runname $runname --chips "abc" --caldir_darks "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_09_21/outdir/" --caldir_flats "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_10_03/outdir/" 
+## set up the output directory (if does not exist)
+#mkdir -p ${outdir}almanac
+#
+## get the data summary file for the MJD
+#almanac -v -p 12 --mjd-start $mjd_start --mjd-end $mjd_end --${tele} --output $almanac_file
+#
+## get the runlist file (julia projects seem to refer to where your cmd prompt is when you call the shell. Here I imaging sitting at ApogeeReduction.jl level)
+#echo "Getting runlist..."
+#julia +1.11.0 --project="./" src/cal_build/make_runlist_dome_flats.jl --tele $tele --almanac_file $almanac_file --output $runlist
+#
+## run the reduction pipeline (all cals like dark sub/flats that would be a problem, should be post 3D->2D extraction)
+#julia +1.11.0 --project="./" pipeline.jl --tele $tele --runlist $runlist --outdir $doutdir --runname $runname --chips "abc" --caldir_darks "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_09_21/outdir/" --caldir_flats "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_10_03/outdir/"
 # make the stacked darks
 mkdir -p ${outdir}dome_flats
 julia +1.11.0 --project="./" src/cal_build/make_traces_domeflats.jl --mjd-start $mjd_start --mjd-end $mjd_end --tele $tele --chip "a" --trace_dir ${doutdir} --runlist $runlist

--- a/src/cal_build/run_trace_cal.sh
+++ b/src/cal_build/run_trace_cal.sh
@@ -17,19 +17,19 @@ doutdir=$outdir
 almanac_file=${outdir}almanac/${runname}.h5
 runlist=${outdir}almanac/runlist_${runname}.jld2
 
-## set up the output directory (if does not exist)
-#mkdir -p ${outdir}almanac
-#
-## get the data summary file for the MJD
-#almanac -v -p 12 --mjd-start $mjd_start --mjd-end $mjd_end --${tele} --output $almanac_file
-#
-## get the runlist file (julia projects seem to refer to where your cmd prompt is when you call the shell. Here I imaging sitting at ApogeeReduction.jl level)
-#echo "Getting runlist..."
-#julia +1.11.0 --project="./" src/cal_build/make_runlist_dome_flats.jl --tele $tele --almanac_file $almanac_file --output $runlist
-#
-## run the reduction pipeline (all cals like dark sub/flats that would be a problem, should be post 3D->2D extraction)
-#julia +1.11.0 --project="./" pipeline.jl --tele $tele --runlist $runlist --outdir $doutdir --runname $runname --chips "abc" --caldir_darks "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_09_21/outdir/" --caldir_flats "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_10_03/outdir/"
-# make the stacked darks
+# set up the output directory (if does not exist)
+mkdir -p ${outdir}almanac
+
+# get the data summary file for the MJD
+almanac -v -p 12 --mjd-start $mjd_start --mjd-end $mjd_end --${tele} --output $almanac_file
+
+# get the runlist file (julia projects seem to refer to where your cmd prompt is when you call the shell. Here I imaging sitting at ApogeeReduction.jl level)
+echo "Getting runlist..."
+julia +1.11.0 --project="./" src/cal_build/make_runlist_dome_flats.jl --tele $tele --almanac_file $almanac_file --output $runlist
+
+# run the reduction pipeline (all cals like dark sub/flats that would be a problem, should be post 3D->2D extraction)
+julia +1.11.0 --project="./" pipeline.jl --tele $tele --runlist $runlist --outdir $doutdir --runname $runname --chips "abc" --caldir_darks "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_09_21/outdir/" --caldir_flats "/uufs/chpc.utah.edu/common/home/sdss42/sdsswork/users/u6039752-1/working/2024_10_03/outdir/"
+ make the stacked darks
 mkdir -p ${outdir}dome_flats
 julia +1.11.0 --project="./" src/cal_build/make_traces_domeflats.jl --mjd-start $mjd_start --mjd-end $mjd_end --tele $tele --chip "a" --trace_dir ${doutdir} --runlist $runlist
 julia +1.11.0 --project="./" src/cal_build/make_traces_domeflats.jl --mjd-start $mjd_start --mjd-end $mjd_end --tele $tele --chip "b" --trace_dir ${doutdir} --runlist $runlist

--- a/src/makie_plotutils.jl
+++ b/src/makie_plotutils.jl
@@ -1,0 +1,13 @@
+# this has the plotting setup used for plotting with Makie
+
+using CairoMakie, ColorSchemes
+sas_prefix = "https://data.sdss5.org/sas/sdsswork/users/"
+
+set_theme!(theme_black());
+
+function nanify(x, msk)
+    out = zeros(eltype(x), length(msk))
+    out[msk] .= x
+    out[.!msk] .= NaN
+    return out
+end

--- a/src/plotutils.jl
+++ b/src/plotutils.jl
@@ -1,3 +1,6 @@
+# this has the plotting setup used for plotting with PythonPlot
+# it should be eliminated once we switch to Makie
+
 ENV["JULIA_CONDAPKG_BACKEND"] = "MicroMamba";
 using CondaPkg;
 using PythonCall;


### PR DESCRIPTION
- parallelizes trace extraction
- switches to CairoMakie for trace extraction plots
- adds `verbose` kwarg to `extract_trace` which is off by default
- add a file `makie_plotutils.jl` for use when using makie instead of pythonplot