### PR TITLE
Adam 2025-03-17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ file_schema/Manifest.toml
 .vscode
 slurm_logs/*.err
 slurm_logs/*.out
-slurm_logs/*.sh
 *.err
 *.out
 

--- a/slurm_logs/dashboard.sh
+++ b/slurm_logs/dashboard.sh
@@ -16,10 +16,6 @@ if tmux has-session -t $BASE_SESSION_NAME 2>/dev/null; then
     SESSION_NAME="${BASE_SESSION_NAME}_$i"
 fi
 
-# Find the most recent SLURM output files
-SLURM_OUT=$(ls -t ar*.out | head -n1)
-SLURM_ERR=$(ls -t ar*.err | head -n1)
-
 # Create a new tmux session
 tmux new-session -d -s $SESSION_NAME
 

--- a/slurm_logs/dashboard.sh
+++ b/slurm_logs/dashboard.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# run this from the slurm_logs directory to get a simple tmux dashboard of the current run
+# it shows: htop on the first node, a live view of the most recent slurm output, and a live view of the slurm queue
+
+# Base name of the tmux session
+BASE_SESSION_NAME="ARjl-dashboard"
+SESSION_NAME=$BASE_SESSION_NAME
+
+# Check if a session with the base name already exists
+if tmux has-session -t $BASE_SESSION_NAME 2>/dev/null; then
+    # Find a unique session name
+    i=1
+    while tmux has-session -t "${BASE_SESSION_NAME}_$i" 2>/dev/null; do
+        ((i++))
+    done
+    SESSION_NAME="${BASE_SESSION_NAME}_$i"
+fi
+
+# Find the most recent SLURM output files
+SLURM_OUT=$(ls -t ar*.out | head -n1)
+SLURM_ERR=$(ls -t ar*.err | head -n1)
+
+# Create a new tmux session
+tmux new-session -d -s $SESSION_NAME
+
+# Function to create a new pane and run a command
+create_pane() {
+    COMMAND=$1
+    tmux split-window -t $SESSION_NAME
+    tmux send-keys -t $SESSION_NAME "$COMMAND" C-m
+}
+
+tmux set -g pane-border-status top
+tmux set -g pane-border-format "#{pane_index} #{pane_current_command}"
+
+# tail the most recent SLURM output file
+tmux send-keys -t $SESSION_NAME "tail -f \"\$(ls ar*.out | sort | tail -n1)\"" C-m
+create_pane "ssh $(squeue -h -o '%N' -u $USER) -t htop -u $USER"
+create_pane "while true; do clear; sq; sleep 10; done"
+
+# Arrange the panes
+tmux select-layout -t $SESSION_NAME main-vertical
+
+# make the right-hand column a little wider
+tmux resize-pane -t $SESSION_NAME -L 20
+
+tmux attach-session -t $SESSION_NAME

--- a/src/cal_build/run_dark_cal.sh
+++ b/src/cal_build/run_dark_cal.sh
@@ -17,7 +17,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_dark_cal.sh
+++ b/src/cal_build/run_dark_cal.sh
@@ -16,7 +16,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_dark_cal.sh
+++ b/src/cal_build/run_dark_cal.sh
@@ -9,7 +9,6 @@
 #SBATCH --time=8:00:00
 #SBATCH --job-name=ApogeeReduction_dark_cal
 #SBATCH --output=slurm_logs/%x_%j.out
-#SBATCH --err=slurm_logs/%x_%j.err
 
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=7155301634@vtext.com

--- a/src/cal_build/run_flat_cal.sh
+++ b/src/cal_build/run_flat_cal.sh
@@ -17,7 +17,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_flat_cal.sh
+++ b/src/cal_build/run_flat_cal.sh
@@ -16,7 +16,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_flat_cal.sh
+++ b/src/cal_build/run_flat_cal.sh
@@ -9,7 +9,6 @@
 #SBATCH --time=8:00:00
 #SBATCH --job-name=ApogeeReduction_flat_cal
 #SBATCH --output=slurm_logs/%x_%j.out
-#SBATCH --err=slurm_logs/%x_%j.err
 
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=7155301634@vtext.com

--- a/src/cal_build/run_trace_cal.sh
+++ b/src/cal_build/run_trace_cal.sh
@@ -9,7 +9,6 @@
 #SBATCH --time=8:00:00
 #SBATCH --job-name=ApogeeReduction_trace_cal
 #SBATCH --output=slurm_logs/%x_%j.out
-#SBATCH --err=slurm_logs/%x_%j.err
 
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=7155301634@vtext.com

--- a/src/cal_build/run_trace_cal.sh
+++ b/src/cal_build/run_trace_cal.sh
@@ -17,7 +17,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_trace_cal.sh
+++ b/src/cal_build/run_trace_cal.sh
@@ -16,7 +16,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -55,6 +55,7 @@ print_elapsed_time() {
 
 # get the data summary file for the MJD
 print_elapsed_time "Running Almanac"
+# switch to almanac -vvv for true verbosity (but only after upgrading to almanac 0.1.5)
 almanac -v -p 12 --mjd-start $mjd --mjd-end $mjd --${tele} --output $almanac_file --fibers
 
 # get the runlist file (julia projects seem to refer to where your cmd prompt is when you call the shell. Here I imagine sitting at ApogeeReduction.jl level)

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -19,7 +19,8 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+# TODO switch to almanac/default once that's working.
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -19,7 +19,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -12,7 +12,6 @@
 #SBATCH --time=8:00:00
 #SBATCH --job-name=ar_all
 #SBATCH --output=slurm_logs/%x_%j.out
-#SBATCH --err=slurm_logs/%x_%j.err
 
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=7155301634@vtext.com

--- a/src/verify_scripts/run_b2b.sh
+++ b/src/verify_scripts/run_b2b.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else

--- a/submit_loc_ex.sh
+++ b/submit_loc_ex.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/submit_loc_ex.sh
+++ b/submit_loc_ex.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/submit_loc_exbatch.sh
+++ b/submit_loc_exbatch.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/submit_loc_exbatch.sh
+++ b/submit_loc_exbatch.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/default sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now


### PR DESCRIPTION
- introduces basic tmux dashboard in `slurm-logs/`
  - related: tweak `SBATCH` directives so that all output goes in `ar<whatever>.out`, (i.e. no separate file for stderr).  I think this is easier to follow, but happy to be overridden.

- `module load almanac/default` everywhere