### PR TITLE
GH trace extraction refactor

### DIFF
--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -68,6 +68,7 @@ Keyword arguments:
 - `n_sub`: the number of sub-pixels to use in the profile
 - `make_plots`: whether to make plots of the profiles
 - `profile_path`: the path to the profile files
+- `plot_path`: the path to save the plots
 
 Returns:
 - `med_center_to_fiber_func`: a function that maps the median fiber center to the fiber index
@@ -79,7 +80,7 @@ Returns:
 - `all_y_prof`: the Gauss-Hermite profiles
 """
 function gh_profiles(tele, mjd, chip, expid;
-        n_sub = 100, make_plots = false, profile_path = "../../data/")
+        n_sub = 100, make_plots = false, profile_path = "../../data/", plot_path = "../outdir/plots/")
 
     # TODO actually get these from the arguments
     if tele == "apo"
@@ -115,8 +116,6 @@ function gh_profiles(tele, mjd, chip, expid;
     fiber_inds = collect(minimum(prof_fiber_inds):maximum(prof_fiber_inds))
 
     if make_plots
-        dirNamePlots = "../outdir/plots/"
-
         for j in 1:n_gauss
             fig = Figure(size = (800, 800))
             ax = Axis(fig[1, 1],
@@ -126,8 +125,8 @@ function gh_profiles(tele, mjd, chip, expid;
 
             scatter!(ax, fiber_inds, smooth_new_indv_heights[:, j])
 
-            tracePlot_heights_Path = dirNamePlots *
-                                     "GH$(j-1)_heights_$(tele)_$(profile_mjd)_$(profile_expid)_$(chip).png"
+            tracePlot_heights_Path = joinpath(plot_path,
+                "GH$(j-1)_heights_$(tele)_$(profile_mjd)_$(profile_expid)_$(chip).png")
             save(tracePlot_heights_Path, fig)
         end
     end
@@ -141,9 +140,7 @@ function gh_profiles(tele, mjd, chip, expid;
     smoothed_cdf_scales = zeros(size(fiber_inds, 1))
     n_offset_pix = 15
 
-    # TODO simplify
-    x = range(start = -n_offset_pix, stop = n_offset_pix, step = 1)
-    x_bins = range(start = x[1] - 0.5, stop = x[end] + 0.5, step = 1 / n_sub)
+    x_bins = range(-n_offset_pix - 0.5, n_offset_pix + 0.5, step = 1 / n_sub)
     cdf = zeros(size(x_bins, 1))
     dcdf_dz = zeros(size(x_bins, 1))
 
@@ -192,8 +189,8 @@ function gh_profiles(tele, mjd, chip, expid;
             lines!(ax, x_centers, pdf .+ 0.02 * (j - 1))
         end
 
-        tracePlot_heights_Path = dirNamePlots *
-                                 "GH_profiles_$(tele)_$(profile_mjd)_$(profile_expid)_$(chip).png"
+        tracePlot_heights_Path = joinpath(plot_path,
+            "GH_profiles_$(tele)_$(profile_mjd)_$(profile_expid)_$(chip).png")
         save(tracePlot_heights_Path, fig)
     end
 

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -112,6 +112,7 @@ function gh_profiles(tele, mjd, chip, expid;
         (params["fiber_index"] .+ 1, params["fiber_median_y_center"] .+ 1, heights, n_gauss)
     end
 
+    # all fiber indices, including the ones that don't have a profile
     fiber_inds = collect(minimum(prof_fiber_inds):maximum(prof_fiber_inds))
 
     if make_plots
@@ -129,11 +130,6 @@ function gh_profiles(tele, mjd, chip, expid;
             save(tracePlot_heights_Path, fig)
         end
     end
-
-    med_center_to_fiber_func = fit(prof_fiber_centers, prof_fiber_inds, 3)
-
-    min_prof_fib = minimum(prof_fiber_inds)
-    max_prof_fib = maximum(prof_fiber_inds)
 
     smoothed_cdf_zeros = zeros(size(fiber_inds, 1))
     smoothed_cdf_scales = zeros(size(fiber_inds, 1))
@@ -193,8 +189,10 @@ function gh_profiles(tele, mjd, chip, expid;
         save(tracePlot_heights_Path, fig)
     end
 
+    med_center_to_fiber_func = fit(prof_fiber_centers, prof_fiber_inds, 3)
+
     return (med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub,
-        min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv)
+        first(fiber_inds), last(fiber_inds), all_y_prof, all_y_prof_deriv)
 end
 
 function cdf_func_indv(x_bins, mean, width, fiber_ind, x_prof_min, x_prof_max_ind,

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -175,7 +175,9 @@ function gh_profiles(tele, mjd, chip, expid;
         save(tracePlot_heights_Path, fig)
     end
 
-    med_center_to_fiber_func = fit(prof_fiber_centers, prof_fiber_inds, 3)
+#    med_center_to_fiber_func = fit(prof_fiber_centers, prof_fiber_inds, 3)
+    med_center_to_fiber_func = linear_interpolation(
+        prof_fiber_centers, prof_fiber_inds, extrapolation_bc = Line())
 
     # things to return
     x_prof_min = first(x_bins)
@@ -807,7 +809,7 @@ function trace_extract(image_data, ivar_image, tele, mjd, chip, expid,
     curr_fiber_inds = clamp.(range(1, size(best_fit_ave_params, 1)), min_prof_fib, max_prof_fib)
 
     med_flux = nanmedian(best_fit_ave_params[:, 1], 1)
-    good_throughput_fibers = (best_fit_ave_params[:, 1] ./ med_flux) .> 0.1
+    good_throughput_fibers = (best_fit_ave_params[:, 1] ./ med_flux) .> 0.05
     low_throughput_fibers = findall(.!good_throughput_fibers)
 
     x_inds = axes(image_data, 1)

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -2,9 +2,6 @@ using Polynomials: fit, Polynomial
 using SpecialFunctions: erf
 using Interpolations: linear_interpolation, Line
 
-profile_path = "/uufs/chpc.utah.edu/common/home/u6057633/scratch/20250226/outdir/trace_profile/"
-#profile_path = "../../data/"
-
 function _gauss_hermite_poly(x, n)
     if n == 1
         ones(size(x))

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -385,7 +385,8 @@ Returns: trace centers, widths, and heights, and their covariances.
 function trace_extract(image_data, ivar_image, tele, mjd, chip, expid,
         med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib,
         max_prof_fib, all_y_prof, all_y_prof_deriv;
-        good_pixels = ones(Bool, size(image_data)), mid = 1025, n_center_cols = 100, verbose = false)
+        good_pixels = ones(Bool, size(image_data)), mid = 1025, n_center_cols = 100, verbose = false,
+	low_throughput_thresh = 0.05)
     noise_image = 1 ./ sqrt.(ivar_image)
     good_pixels .= good_pixels .& (ivar_image .> 0)
     #     n_center_cols = 100 # +/- n_cols to use from middle to sum to find peaks
@@ -809,7 +810,7 @@ function trace_extract(image_data, ivar_image, tele, mjd, chip, expid,
     curr_fiber_inds = clamp.(range(1, size(best_fit_ave_params, 1)), min_prof_fib, max_prof_fib)
 
     med_flux = nanmedian(best_fit_ave_params[:, 1], 1)
-    good_throughput_fibers = (best_fit_ave_params[:, 1] ./ med_flux) .> 0.05
+    good_throughput_fibers = (best_fit_ave_params[:, 1] ./ med_flux) .> low_throughput_thresh
     low_throughput_fibers = findall(.!good_throughput_fibers)
 
     x_inds = axes(image_data, 1)

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -78,7 +78,7 @@ Returns a tuple of:
 - `all_y_prof_deriv`: the derivatives of the Gauss-Hermite profiles
 """
 function gh_profiles(tele, mjd, chip, expid;
-        n_sub = 100, make_plots = false, profile_path = "../../data/", plot_path = "../outdir/plots/")
+        n_sub = 100, make_plots = false, profile_path = "./data/", plot_path = "../outdir/plots/")
 
     # TODO actually get these from the arguments
     if tele == "apo"

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -386,7 +386,7 @@ function trace_extract(image_data, ivar_image, tele, mjd, chip, expid,
         med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib,
         max_prof_fib, all_y_prof, all_y_prof_deriv;
         good_pixels = ones(Bool, size(image_data)), mid = 1025, n_center_cols = 100, verbose = false,
-	low_throughput_thresh = 0.05)
+        low_throughput_thresh = 0.05)
     noise_image = 1 ./ sqrt.(ivar_image)
     good_pixels .= good_pixels .& (ivar_image .> 0)
     #     n_center_cols = 100 # +/- n_cols to use from middle to sum to find peaks

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -20,7 +20,7 @@
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
 # TODO switch to almanac/default once that's working.
-module load sdssdb/main almanac/0.1.4 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else
@@ -66,7 +66,7 @@ julia +1.11.0 --project="./" src/run_scripts/make_runlist_all.jl --tele $tele --
 # Run the reduction pipeline to 2D/2Dcal and stop
 print_elapsed_time "Running 3D->2D/2Dcal Pipeline"
 # --workers_per_node 28 ## sometimes have to adjust this, could programmatically set based on the average or max read number in the exposures for that night
-julia +1.11.0 --project="./" pipeline.jl --tele $tele --runlist $runlist --outdir $outdir --runname $runname --chips "abc" --caldir_darks $caldir_darks --caldir_flats $caldir_flats
+julia +1.11.0 --project="./" pipeline.jl --tele $tele --runlist $runlist --outdir $outdir --runname $runname --chips "abc" --caldir_darks $caldir_darks --caldir_flats $caldir_flats --workers_per_node 28
 
 # Only continue if run_2d_only is false
 if [ "$run_2d_only" != "true" ]; then

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -20,7 +20,7 @@
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
 # TODO switch to almanac/default once that's working.
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else


### PR DESCRIPTION
This PR does a few things:
- adds a couple docstrings with high-level descriptions of what the functions do.  @KevinMcK95, can you check that these are correct?
- turns `profile_path` from a global to a keyword argument of `gh_profiles`, which is the only place it's used.
- internal refactoring of `gh_profiles`.  As I changed things, I verified that the outputs for `expid = "51770010", chip = "b"` where exactly maintained.
	- make `dirNamePlots` a keyword argument, called `plot_path` with the default value matching the old behavior.
	- use `joinpath` where appropriate to construct paths. (Don't really think this is a big deal since this code always runs on Utah, but the LLM insisted and I didn't argue.)
	- move things that are computer and returned without being used to the end of the function
	- eliminate some unnecessary intermediate arrays.

In case anyone is curious, the way that I made sure not to chagne behavior was to edit `traceExtract_GH.jl` directly, and to run the following before each commit:
```julia
include("./src/cal_build/traceExtract_GH.jl")
@time new_med_center_to_fiber_func, new_x_prof_min, new_x_prof_max_ind, new_n_sub, new_min_prof_fib, new_max_prof_fib, new_all_y_prof, new_all_y_prof_deriv = gh_profiles(
    tele, mjd, chip, expid; n_sub = 100, profile_path = "/uufs/chpc.utah.edu/common/home/u6057633/scratch/20250226/outdir/trace_profile/")

using Test
@testset "gh_profiles refactor" begin
    @test med_center_to_fiber_func == new_med_center_to_fiber_func
    @test x_prof_min == new_x_prof_min
    @test x_prof_max_ind == new_x_prof_max_ind
    @test n_sub == new_n_sub
    @test min_prof_fib == new_min_prof_fib
    @test max_prof_fib == new_max_prof_fib
    @test all_y_prof == new_all_y_prof
    @test all_y_prof_deriv == new_all_y_prof_deriv
end
```