### PR TITLE
Sub-class `FileSensor` to `TransferFileSensor` to skip checking for ancient "done" files\

### DIFF
--- a/dags/main.py
+++ b/dags/main.py
@@ -142,7 +142,7 @@ with DAG(
 
             # If the data interval start is more than a week ago, don't wait for the file transfer.
             recency = BranchPythonOperator(
-                task_id="check_recency",
+                task_id="recency",
                 python_callable=lambda data_interval_start, **_: "darks" if data_interval_start < (datetime.now(data_interval_start.tz) - timedelta(weeks=1)) else "transfer"
                 provide_context=True
             )
@@ -207,6 +207,7 @@ with DAG(
                 ]               
             )   
             initial_notification >> recency >> [transfer, darks] >> flats >> science
+            transfer >> darks # necessary if we awaited the transfer
             
         observatory_groups.append(group)
 


### PR DESCRIPTION
If the data are old then there won't be a `*.done` path indicating the transfer is complete. This adds a `BranchOperator` that will skip the `FileSensor` step if the data are more than a week old. We can adjust this timing on that choice, but this is a proof of concept. 

I thought it better to set it up as a `BranchPythonOperator` so we can visibly see (from the web interface) when an operator was skipped or when it spent time waiting for files.