### PR TITLE
correctly pull data from new almanac files

### DIFF
--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -248,14 +248,13 @@ function get_fibTargDict(f, tele, mjd, expid)
         # Plate era
         "science" => "sci",
         "standard" => "tel",
-        "sky" => "sky",
-
-        # TODO other fiber types:
-        # "blank"s from plate era
-        # FPI era "serendipitous" APOGEE fibers are those which "accidentally" point at a bright
-        # star (for BOSS reasons).
-        # TODO Andrew thinks the fibers with category "" might be serendipitous targets
+        "sky" => "sky"
     )
+    # TODO other fiber types:
+    # "blank"s from plate era
+    # FPI era "serendipitous" APOGEE fibers are those which "accidentally" point at a bright
+    # star (for BOSS reasons).
+    # TODO Andrew thinks the fibers with category "" might be serendipitous targets
 
     mjdfps2plate = get_fps_plate_divide(tele)
     configName, configIdCol, target_type_col = if mjd > mjdfps2plate
@@ -286,7 +285,6 @@ function get_fibTargDict(f, tele, mjd, expid)
             else
                 error("fiber_id or fiberid column not found in $(configName)/$(configid). Available columns: $(names(df_fib))")
             end
-
 
             fiber_types = map(df_fib[!, target_type_col]) do t
                 if t in keys(fiber_type_names)

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -232,32 +232,76 @@ function extract_optimal_iter(dimage, ivarimage, pix_bitmask, trace_params,
     flux_1d, ivar_1d, mask_1d
 end
 
+"""
+Given an open HDF.file, `f`, and the telescope, mjd, and expid, return a dictionary mapping fiber id
+to fiber type.
+"""
 function get_fibTargDict(f, tele, mjd, expid)
     # translate confSummary/almanac terminology to AR.jl terminology
-    fps_era_fiber_category_names = Dict(
+    fiber_type_names = Dict(
+        # fps era
         "science" => "sci",
         "sky_boss" => "skyB",
         "standard_apogee" => "tel",
-        "sky_apogee" => "sky"
+        "sky_apogee" => "sky",
+
+        # Plate era
+        "science" => "sci",
+        "standard" => "tel",
+        "sky" => "sky",
+
+        # TODO other fiber types:
+        # "blank"s from plate era
+        # FPI era "serendipitous" APOGEE fibers are those which "accidentally" point at a bright
+        # star (for BOSS reasons).
+        # TODO Andrew thinks the fibers with category "" might be serendipitous targets
     )
-    # other fiber types:
-    # "blank"s from plate era
-    # FPI era "serendipitous" APOGEE fibers are those which "accidentally" point at a bright
-    # star (for BOSS reasons).
 
-    # worry about the read-in overhead per expid?
-    df_exp = DataFrame(read(f["$(tele)/$(mjd)/exposures"]))
     mjdfps2plate = get_fps_plate_divide(tele)
-    configName = (mjd > mjdfps2plate) ? "fps" : "plates"
-    configIDname = (mjd > mjdfps2plate) ? "configid" : "plateid"
-    configNumStr = df_exp[expid, Symbol(configIDname)]
+    configName, configIdCol, target_type_col = if mjd > mjdfps2plate
+        "fps", "configid", "category"
+    else
+        "plates", "plateid", "target_type" # TODO should this be source_type?
+    end
 
-    fibtargDict = if (df_exp.exptype[expid] == "OBJECT")
+    df_exp = DataFrame(read(f["$(tele)/$(mjd)/exposures"]))
+    if !(expid in df_exp.exposure)
+        @warn "Exposure $(expid) not found in $(tele)/$(mjd)/exposures"
+        return Dict(1:300 .=> "fiberTypeFail")
+    end
+    exposure_info = df_exp[findfirst(df_exp[!, "exposure"] .== expid), :]
+    configid = exposure_info[configIdCol]
+
+    fibtargDict = if exposure_info.exptype == "OBJECT"
         try
-            df_fib = DataFrame(read(f["$(tele)/$(mjd)/fibers/$(configName)/$(configNumStr)"]))
-            Dict(parse.(Int, df_fib[!, "fiber_id"]) .=>
-                get.(fps_era_fiber_category_names, df_fib[!, "category"]))
-        catch
+            df_fib = DataFrame(read(f["$(tele)/$(mjd)/fibers/$(configName)/$(configid)"]))
+            # normalizes all column names to lowercase
+            rename!(df_fib, lowercase.(names(df_fib)))
+
+            # sometimes the fiber id column is called "fiber_id" and sometimes it is called "fiberid"
+            fiberid_col = if "fiber_id" in names(df_fib)
+                "fiber_id"
+            elseif "fiberid" in names(df_fib)
+                "fiberid"
+            else
+                error("fiber_id or fiberid column not found in $(configName)/$(configid). Available columns: $(names(df_fib))")
+            end
+
+
+            fiber_types = map(df_fib[!, target_type_col]) do t
+                if t in keys(fiber_type_names)
+                    fiber_type_names[t]
+
+                else
+                    @warn "Unknown fiber type for $(tele)/$(mjd)/fibers/$(configName)/$(configid): $(repr(t))"
+                    "fiberTypeFail"
+                end
+            end
+            Dict(df_fib[!, fiberid_col] .=> fiber_types)
+        catch e
+            rethrow(e)
+            @warn "Failed to get any fiber type information for $(tele)/$(mjd)/fibers/$(configName)/$(configid) (exposure $(expid)). Returning fiberTypeFail for all fibers."
+            show(e)
             Dict(1:300 .=> "fiberTypeFail")
         end
     else

--- a/src/cal_build/run_dark_cal.sh
+++ b/src/cal_build/run_dark_cal.sh
@@ -16,7 +16,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_flat_cal.sh
+++ b/src/cal_build/run_flat_cal.sh
@@ -16,7 +16,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/cal_build/run_trace_cal.sh
+++ b/src/cal_build/run_trace_cal.sh
@@ -16,7 +16,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/src/fileNameHandling.jl
+++ b/src/fileNameHandling.jl
@@ -26,8 +26,17 @@ function build_raw_path(obs, mjd, chip, expid)
     return join([base, obs, mjd, fname], "/")
 end
 
+function short_expid_to_long(mjd, expid)
+    # this should probably be done with math
+    return parse(Int, string(mjd - 55562) * lpad(expid, 4, "0"))
+end
+
+function long_expid_to_short(mjd, expid)
+    return expid - (mjd - 55562) * 10000
+end
+
 function get_cal_file(parent_dir, tele, mjd, expid, chip, imtype; use_cal = false)
-    expid_adj = string(mjd - 55562) * lpad(expid, 4, "0") # what a fun forced hard code!
+    expid_adj = short_expid_to_long(mjd, expid)
     if use_cal
         fname_type = "ar2Dcal"
     else
@@ -77,6 +86,6 @@ function get_fps_plate_divide(tele)
     if (tele == "apo")
         return 59423
     elseif (tele == "lco")
-        return 59810 # still need to confirm this 
+        return 59810 # still need to confirm this
     end
 end

--- a/src/run_scripts/run_all.sh
+++ b/src/run_scripts/run_all.sh
@@ -20,7 +20,7 @@
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
 # TODO switch to almanac/default once that's working.
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else

--- a/src/verify_scripts/run_b2b.sh
+++ b/src/verify_scripts/run_b2b.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main sdsstools postgresql ffmpeg
 if [ -n "$SLURM_JOB_NODELIST" ]; then
     echo $SLURM_JOB_NODELIST
 else

--- a/submit_loc_ex.sh
+++ b/submit_loc_ex.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now

--- a/submit_loc_exbatch.sh
+++ b/submit_loc_exbatch.sh
@@ -3,7 +3,7 @@
 
 # load all of the modules to talk to the database (need to be on Utah)
 # should turn this off as an option for users once the MJD summaries are generated
-module load sdssdb/main almanac/0.1.6 sdsstools postgresql ffmpeg
+module load sdssdb/main almanac/main sdsstools postgresql ffmpeg
 juliaup add 1.11.0
 
 # hardcode the mjd and expid for now


### PR DESCRIPTION
This PR updates the almanac output reader to reflect the new format.  It also adds much more explanatory errors and warnings.

I've tested this directly on some almanac outputs, and haven't found any problems.  Currently reprocessing lco SJD 60764, to confirm that everything works and the files propagate to slack.