### PR TITLE
dealing with safe_jldsave wrinkles

### DIFF
--- a/src/cal_build/make_relFlux.jl
+++ b/src/cal_build/make_relFlux.jl
@@ -1,4 +1,5 @@
 using ArgParse, Distributed, SlurmClusterManager, SlackThreads
+include("../utils.jl") # for safe_jldsave
 
 ## Parse command line arguments
 function parse_commandline()
@@ -105,7 +106,7 @@ for mjd in unique_mjds
 end
 
 ## need to get cal_type from runlist
-exp_type_lst = map(x->split(split(x, "FLAT")[1], "_")[end], all1Da)
+exp_type_lst = map(x -> split(split(x, "FLAT")[1], "_")[end], all1Da)
 unique_exp_lst = unique(exp_type_lst)
 if length(unique_exp_lst) > 1
     error("Multiple cal types found in runlist")
@@ -115,12 +116,12 @@ cal_type = lowercase(unique_exp_lst[1])
 
 flist_chips = []
 for chip in chips
-    push!(flist_chips, replace.(all1Da, "_a_"=>"_$(chip)_"))
+    push!(flist_chips, replace.(all1Da, "_a_" => "_$(chip)_"))
 end
 all1D = vcat(flist_chips...)
 
 all1Daout = map(
-    x->replace(replace(x, "apred"=>"$(cal_type)_flats"), "ar1Dcal" => "$(cal_type)Flux"), all1Da)
+    x -> replace(replace(x, "apred" => "$(cal_type)_flats"), "ar1Dcal" => "$(cal_type)Flux"), all1Da)
 dname = dirname(all1Daout[1])
 if !ispath(dname)
     mkpath(dname)
@@ -130,7 +131,7 @@ end
     function get_and_save_relFlux(fname)
         absthrpt, relthrpt, bitmsk_relthrpt = get_relFlux(fname)
         outfname = replace(
-            replace(fname, "apred"=>"$(cal_type)_flats"), "ar1Dcal" => "$(cal_type)Flux")
+            replace(fname, "apred" => "$(cal_type)_flats"), "ar1Dcal" => "$(cal_type)Flux")
         safe_jld2save(outfname; absthrpt, relthrpt, bitmsk_relthrpt)
     end
 end
@@ -157,7 +158,7 @@ thread("$(cal_type) relFluxing")
         relthrpt = zeros(300, length(chips))
         bitmsk_relthrpt = zeros(Int, 300, length(chips))
         for (cindx, chip) in enumerate(chips)
-            local_fname = replace(fname, "_a_"=>"_$(chip)_")
+            local_fname = replace(fname, "_a_" => "_$(chip)_")
             f = jldopen(local_fname)
             absthrpt[:, cindx] = f["absthrpt"]
             relthrpt[:, cindx] = f["relthrpt"]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,19 +169,31 @@ normal_pdf(Δ, σ) = exp(-0.5 * Δ^2 / σ^2) / √(2π) / σ
 """
 This function is a wrapper around JLD2.jldsave that checks if the types of the values to be saved
 will result in a hard-to-read HDF5 file and warn if so.
+
+It also converts BitArrays to Array{Bool} if necessary, this means that the saved data will be 8x
+larger (Bools are 1 byte), even when read back into Julia.
 """
 function safe_jldsave(filename; kwargs...)
+    to_save = Dict{Symbol, Any}()
     for (k, v) in kwargs
-        t = if isa(v, Array)
-            eltype(v)
+        # convert BitArray to Array{Bool} if necessary
+        if v isa BitArray
+            to_save[k] = convert(Array{Bool}, v)
         else
-            typeof(v)
-        end
-        if !(t in [Bool, Int, Int64, Int32, Int16, Int8, UInt, UInt64, UInt32,
-            UInt16, UInt8, Float64, Float32, String])
-            #throw(ArgumentError("When saving to JLD, only types Strings and standard numerical types are supported. Type $t, which is being used for key $k, will result in a hard-to-read HDF5 file."))
-            @warn "When saving to JLD, only types Strings and standard numerical types are supported. Type $t, which is being used for key $k, will result in a hard-to-read HDF5 file."
+            to_save[k] = v
+
+            # if the value will result in a hard-to-read HDF5 file, warn
+            t = if isa(v, Array)
+                eltype(v)
+            else
+                typeof(v)
+            end
+            if !(t in [Bool, Int, Int64, Int32, Int16, Int8, UInt, UInt64, UInt32,
+                UInt16, UInt8, Float64, Float32, String])
+                #throw(ArgumentError("When saving to JLD, only types Strings and standard numerical types are supported. Type $t, which is being used for key $k, will result in a hard-to-read HDF5 file."))
+                @warn "When saving to JLD, only types Strings and standard numerical types are supported. Type $t, which is being used for key $k, will result in a hard-to-read HDF5 file."
+            end
         end
     end
-    JLD2.jldsave(filename; kwargs...)
+    JLD2.jldsave(filename; to_save...)
 end


### PR DESCRIPTION
- deal with bitarrays by converting to Array{Bool}. These will take up more space, but the files will be nicer.  Automatically converting back to bitarrays when read back into the pipeline is something we should consider in the future.
- include `utils.jl` (and thus `safe_jldsave` in `make_relFlux.jl`