### PR TITLE
traces propagated to 1D spectra and arc/sky/fpi peaks

### DIFF
--- a/pipeline_2d_1d.jl
+++ b/pipeline_2d_1d.jl
@@ -216,10 +216,12 @@ flush(stdout);
             end
 
             # we probably want to append info from the fiber dictionary from alamanac into the file name
-            safe_jldsave(outfname, metadata; flux_1d, ivar_1d, mask_1d,
+            safe_jldsave(outfname, metadata; flux_1d, ivar_1d, mask_1d, 
+		extract_trace_centers = regularized_trace_params[:, :, 2],
                 relthrpt, bitmsk_relthrpt, fiberTypeList)
         else
-            safe_jldsave(outfname, metadata; flux_1d, ivar_1d, mask_1d)
+            safe_jldsave(outfname, metadata; flux_1d, ivar_1d, mask_1d,
+		extract_trace_centers = regularized_trace_params[:, :, 2])
         end
         close(falm)
     end
@@ -343,6 +345,7 @@ end
 all1DObjecta = vcat(list1DexpObject...)
 all1DFPIa = vcat(list1DexpFPI...)
 all1DArclampa = vcat(list1DexpArclamp...)
+all1DfpiPeaks_a = replace.(replace.(all1DFPIa, "ar1Dcal" => "fpiPeaks"), "ar1D" => "fpiPeaks")
 
 all1DObjectperchip = []
 all1DArclampperchip = []

--- a/src/cal_build/make_relFlux.jl
+++ b/src/cal_build/make_relFlux.jl
@@ -166,7 +166,7 @@ thread("$(cal_type) relFluxing")
         bitmsk_relthrpt = zeros(Int, 300, length(chips))
         cartid = Int(read_metadata(fname)["cartid"])
         for (cindx, chip) in enumerate(chips)
-            local_fname = replace(fname, "_a_" => "_$(chiploc)_")
+            local_fname = replace(fname, "_$(chiploc)_" => "_$(chip)_")
             f = jldopen(local_fname)
             absthrpt[:, cindx] = f["absthrpt"]
             relthrpt[:, cindx] = f["relthrpt"]
@@ -180,7 +180,7 @@ thread("$(cal_type) relFluxing")
         # plot the relFlux
         fig = Figure(size = (1200, 400))
         for (cindx, chip) in enumerate(chips)
-            ax = Axis(fig[1, cindx], title = "RelFlux Chip $(chiploc)")
+            ax = Axis(fig[1, cindx], title = "RelFlux Chip $(chip)")
             msk = bitmsk_relthrpt[:, cindx] .== 0
             broken_msk = (bitmsk_relthrpt[:, cindx] .& 2^1) .== 2^1
             warn_msk = (bitmsk_relthrpt[:, cindx] .& 2^0) .== 2^0
@@ -192,14 +192,14 @@ thread("$(cal_type) relFluxing")
             scatter!(ax, xvec[broken_msk], relthrpt[broken_msk, cindx], color = "red")
             broken_fibers = xvec[broken_msk]
             if !isempty(broken_fibers) && (chip == "c") # hardcoded for now
-                status_str *= "\nChip $(chiploc) Broken Fibers:\n    $(join(broken_fibers, "\n    "))"
+                status_str *= "\nChip $(chip) Broken Fibers:\n    $(join(broken_fibers, "\n    "))"
             end
 
             # Warn fibers
             scatter!(ax, xvec[warn_only_msk], relthrpt[warn_only_msk, cindx], color = "orange")
             warn_fibers = xvec[warn_only_msk]
             if !isempty(warn_fibers) && (chip == "c") # hardcoded for now
-                status_str *= "\nChip $(chiploc) Warning Fibers:\n    $(join(warn_fibers, "\n    "))"
+                status_str *= "\nChip $(chip) Warning Fibers:\n    $(join(warn_fibers, "\n    "))"
             end
         end
 

--- a/src/cal_build/traceExtract_GH.jl
+++ b/src/cal_build/traceExtract_GH.jl
@@ -880,6 +880,9 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
         else
             right_cut_ind = size(new_params, 1)
         end
+    else
+        left_cut_ind = 1
+        right_cut_ind = size(new_params, 1)
     end
 
     #identify which fibers should be kept using the prior_center_to_fiber_func

--- a/src/skyline_peaks.jl
+++ b/src/skyline_peaks.jl
@@ -251,6 +251,7 @@ function get_and_save_sky_peaks(fname, roughwave_dict, df_sky_lines)
 
     f = jldopen(fname, "r+")
     flux_1d = f["flux_1d"]
+    extract_trace_centers = f["extract_trace_centers"]
     close(f)
     function get_sky_peaks_partial(flux_1d)
         get_sky_peaks(flux_1d, tele, chip, roughwave_dict, df_sky_lines)
@@ -268,7 +269,10 @@ function get_and_save_sky_peaks(fname, roughwave_dict, df_sky_lines)
     end
     sky_line_mat = zeros(
         Float64, length(unique_skyline_inds), size(pout[first_valid_idx][1], 1), N_FIBERS)
+    sky_trace_centers = zeros(
+        Float64, length(unique_skyline_inds), N_FIBERS)
     fill!(sky_line_mat, NaN)
+    x_pixels = collect(1:N_XPIX)
     for i in 1:N_FIBERS
         for (eindx, skyindx) in enumerate(unique_skyline_inds)
             if !isnothing(pout[i][1])
@@ -278,6 +282,7 @@ function get_and_save_sky_peaks(fname, roughwave_dict, df_sky_lines)
                 end
             end
         end
+	sky_trace_centers[:, i] .= linear_interpolation(x_pixels, extract_trace_centers[:, i], extrapolation_bc = Line()).(sky_line_mat[:,1,i])
     end
 
     medx_detect = running_median.(eachrow(sky_line_mat[:, 1, :]), 31, :asym_trunc, nan = :ignore)
@@ -302,6 +307,10 @@ function get_and_save_sky_peaks(fname, roughwave_dict, df_sky_lines)
     attrs(f["sky_line_mat"])["axis_1"] = "skylineID"
     attrs(f["sky_line_mat"])["axis_2"] = "fit_info"
     attrs(f["sky_line_mat"])["axis_3"] = "fibers"
+
+    write(f, "sky_line_trace_centers", sky_trace_centers)
+    attrs(f["sky_line_trace_centers"])["axis_1"] = "skylineID"
+    attrs(f["sky_line_trace_centers"])["axis_2"] = "fibers"
 
     # Write boff data
     write(f, "boff", boff)


### PR DESCRIPTION
Trace positions (y positions on the detector) propagated to the 1D files, including the interpolated spectra.

Also fixed some plotting of relFlux (all chips being shown now, not just chip a). 