### PR TITLE
single source of truth for error bits

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,3 +42,28 @@ jobs:
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Install dependencies
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - name: Build and deploy
+        run: julia --color=yes --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ slurm_logs/*.sh
 *.out
 *.txt
 *.log
+docs/build/
 
 stash/
 .gitignore

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://github.com/andrew-saydjari/ApogeeReduction.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/andrew-saydjari/ApogeeReduction.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/andrew-saydjari/ApogeeReduction.jl/branch/main/graph/badge.svg?branch=main)](https://codecov.io/gh/andrew-saydjari/ApogeeReduction.jl)
 
+For error bit definitions, see [docs/src/error_bits.md](docs/src/error_bits.md).
+
 ## Files
 The pipeline produces files at many stages of reduction.
 - `ar3Dcal`: Raw 3D datacubes. These are zero point adjusted 3D inputs into the photoelectron rate extractions and are experimental (not always created).
@@ -54,28 +56,6 @@ Nightly Runs:
 
 Bulk reprocessing workflow is still TBD, but the massive parallelization we have designed even for nightly runs means it should be similar, with possible interruptions to build higher signal to noise calibrations based on combining many calibration exposures.
 
-## Current Flag Bits
-
-Certain pixels are entirely masked or have data of questionable quality. This pipeline bit gives insight into the root cause of why this (tiny fraction of the) data is unable to be processed.
-
-| Bit   | Value     | Meaning     |
-| ----- | --------- | ----------- |
-| -     | 0         | No problems       |
-| 0     | 1         | reference array pixels |
-| 1     | 2         | reference pixels |
-| 2     | 4         | bad reference pixels |
-| 3     | 8         | pixels not dark corrected |
-| 4     | 16        | pixels with negative dark current |
-| 5     | 32        | pixels with large dark current |
-| 6     | 64        | flat response too low |
-| 7     | 128       | reads dropped for CR rejection = 1 |
-| 8     | 256       | reads dropped for CR rejection > 1 |
-| 9     | 512       | bad linear SUTR chi2 |
-| 10    | 1024      | failed 1D extraction |
-| 11    | 2048      | no nearby good pixels in 1D extraction |
-| 12    | 4096      | neff>10 in 1D extraction |
-| 13    | 8192      | pixel partially saturated |
-| 14    | 16384     | pixel fully saturated |
 
 
 ## Testing

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,27 @@
+using Pkg
+Pkg.activate(dirname(@__DIR__))
+using ApogeeReduction
+Pkg.activate(@__DIR__)
+using Documenter
+
+DocMeta.setdocmeta!(ApogeeReduction, :DocTestSetup, :(using ApogeeReduction); recursive=true)
+
+makedocs(;
+    modules=[ApogeeReduction],
+    authors="Andrew Saydjari <saydjari@cfa.harvard.edu> and contributors",
+    sitename="ApogeeReduction.jl",
+    format=Documenter.HTML(;
+        canonical="https://andrew-saydjari.github.io/ApogeeReduction.jl",
+        edit_link="main",
+        assets=String[],
+    ),
+    pages=[
+        "Home" => "index.md",
+        "Error Bits" => "error_bits.md",
+    ],
+)
+
+deploydocs(;
+    repo="github.com/andrew-saydjari/ApogeeReduction.jl",
+    devbranch="main",
+)

--- a/docs/src/error_bits.md
+++ b/docs/src/error_bits.md
@@ -1,0 +1,7 @@
+# Error Bit Definitions
+
+```@eval
+using ..ApogeeReduction
+using Markdown
+Markdown.parse(ApogeeReduction.error_bits_markdown_table())
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,3 @@
+```@autodocs
+Modules = [ApogeeReduction]
+```

--- a/src/ApogeeReduction.jl
+++ b/src/ApogeeReduction.jl
@@ -19,6 +19,7 @@ include("ar3D.jl")
 include("ar2Dcal.jl")
 include("ar1D.jl")
 include("fileNameHandling.jl")
+include("error_bits.jl")
 include("utils.jl")
 
 include("wavecal.jl")

--- a/src/error_bits.jl
+++ b/src/error_bits.jl
@@ -1,0 +1,64 @@
+# Error bit definitions and descriptions
+const ERROR_BIT_DEFINITIONS = [
+    (0, 1, "reference array pixels"),
+    (1, 2, "reference pixels"),
+    (2, 4, "bad reference pixels"),
+    (3, 8, "pixels not dark corrected"),
+    (4, 16, "pixels with negative dark current"),
+    (5, 32, "pixels with large dark current"),
+    (6, 64, "flat response too low"),
+    (7, 128, "reads dropped for CR rejection = 1"),
+    (8, 256, "reads dropped for CR rejection > 1"),
+    (9, 512, "bad linear SUTR chi2"),
+    (10, 1024, "failed 1D extraction"),
+    (11, 2048, "no nearby good pixels in 1D extraction"),
+    (12, 4096, "neff>10 in 1D extraction"),
+    (13, 8192, "pixel partially saturated"),
+    (14, 16384, "pixel fully saturated")
+]
+
+# bad_dark_pix_bits = 2^2 + 2^4 #+ 2^5; temporarily remove 2^5 from badlist for now
+bad_dark_pix_bits = 2^1 + 2^2 + 2^4
+bad_flat_pix_bits = 2^6;
+# most multiread CR detections are bad for other reasons
+bad_cr_pix_bits = 2^7 + 2^8; # could probably drop 2^7 at least in the future (happily correct 1 read CRs)
+bad_chi2_pix_bits = 2^9;
+
+# flags for 1d flux extraction
+bad_1d_failed_extract = 2^10;
+bad_1d_no_good_pix = 2^11;
+bad_1d_neff = 2^12;
+
+bad_pix_bits = bad_dark_pix_bits + bad_flat_pix_bits + bad_cr_pix_bits + bad_chi2_pix_bits +
+               bad_1d_failed_extract + bad_1d_no_good_pix + bad_1d_neff;
+
+# Pretty-print error bits
+function print_error_bits(error_value::Integer)
+    if error_value == 0
+        println("No error bits set (value: 0)")
+        return
+    end
+
+    println("Error bits set for value $error_value:")
+    for (bit_num, bit_value, description) in ERROR_BIT_DEFINITIONS
+        if (error_value & bit_value) != 0
+            println("  Bit $bit_num ($bit_value): $description")
+        end
+    end
+end
+
+# Generate markdown table for error bit definitions
+function error_bits_markdown_table()
+    io = IOBuffer()
+
+    # Header with alignment specification
+    println(io, "| Bit Number | Bit Value | Description |")
+    println(io, "|------------|-----------|:------------|")
+
+    # Rows
+    for (bit_num, bit_value, description) in ERROR_BIT_DEFINITIONS
+        println(io, "| $bit_num | $bit_value | $description |")
+    end
+
+    return String(take!(io))
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,21 +31,6 @@ end
 # but it is a symptom of the fact that the include situation is a bit tangled
 git_branch, git_commit = initalize_git("./")
 
-# bad_dark_pix_bits = 2^2 + 2^4 #+ 2^5; temporarily remove 2^5 from badlist for now
-bad_dark_pix_bits = 2^1 + 2^2 + 2^4
-bad_flat_pix_bits = 2^6;
-# most multiread CR detections are bad for other reasons
-bad_cr_pix_bits = 2^7 + 2^8; # could probably drop 2^7 at least in the future (happily correct 1 read CRs)
-bad_chi2_pix_bits = 2^9;
-
-# flags for 1d flux extraction
-bad_1d_failed_extract = 2^10;
-bad_1d_no_good_pix = 2^11;
-bad_1d_neff = 2^12;
-
-bad_pix_bits = bad_dark_pix_bits + bad_flat_pix_bits + bad_cr_pix_bits + bad_chi2_pix_bits +
-               bad_1d_failed_extract + bad_1d_no_good_pix + bad_1d_neff;
-
 function isnanorzero(x)
     return isnan(x) | iszero(x)
 end
@@ -195,7 +180,7 @@ function jack_std(x)
 end
 
 normal_pdf(Δ, σ) = exp(-0.5 * Δ^2 / σ^2) / √(2π) / σ
-normal_cdf(Δ, σ) = 0.5 * (1 + erf((Δ / σ) / √(2))) 
+normal_cdf(Δ, σ) = 0.5 * (1 + erf((Δ / σ) / √(2)))
 
 # used by safe_jldsave
 function check_type_for_jld2(value)


### PR DESCRIPTION
Create a single source of truth for the interpretation of error bits. This is easier to keep in sync and could potentially enable more ergonomic tooling for handling error bits later.

In order to display the bit meanings for reference, set up automatic docs and generate a table of bits there.