### PR TITLE
fixed missing functions from recent refactor

### DIFF
--- a/pipeline_2d_1d.jl
+++ b/pipeline_2d_1d.jl
@@ -109,7 +109,7 @@ flush(stdout);
     using AstroTime # can remove after Adam merges the PR to recast as Float
     using ParallelDataTransfer, ProgressMeter
     using ApogeeReduction
-    using ApogeeReduction: read_almanac_exp_df, gh_profiles, read_metadata, regularize_trace, extract_boxcar, extract_optimal_iter, safe_jldsave, get_fluxing_file, get_fibTargDict, get_1d_name, get_and_save_sky_wavecal, get_and_save_sky_dither_per_fiber, get_and_save_sky_peaks, get_ave_night_wave_soln, sky_wave_plots, reinterp_spectra
+    using ApogeeReduction: read_almanac_exp_df, gh_profiles, read_metadata, regularize_trace, extract_boxcar, extract_optimal_iter, safe_jldsave, get_fluxing_file, get_fibTargDict, get_1d_name, get_and_save_sky_wavecal, get_and_save_sky_dither_per_fiber, get_and_save_sky_peaks, get_ave_night_wave_soln, sky_wave_plots, reinterp_spectra, get_and_save_arclamp_peaks, get_and_save_fpi_peaks, comb_exp_get_and_save_fpi_wavecal
 
     include("src/makie_plotutils.jl")
 

--- a/scripts/monitor/wave_soln.jl
+++ b/scripts/monitor/wave_soln.jl
@@ -4,7 +4,8 @@ using JLD2, ProgressMeter, ArgParse, SlackThreads, Glob, StatsBase, Optim
 using Polynomials: Polynomial
 
 using ApogeeReduction
-src_dir = "../"
+using ApogeeReduction: nanmedian, nanzeropercentile
+src_dir = "../../src/"
 include(src_dir * "/makie_plotutils.jl")
 
 ## Parse command line arguments


### PR DESCRIPTION
Recent refactor meant that some functions (hidden in try expect blocks... Whoops!) weren't explicitly imported in pipeline_2d_1d.jl, so I've added those in. Local testing on recent apo and lco dates (60861) shows that this has fixed the issues.

Also fixed some bad pathways for the wavelength solution monitoring script. 