### PR TITLE
git_clean flag

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,23 +13,24 @@ function initalize_git(git_dir)
         git_repo = LibGit2.GitRepo(git_dir)
         git_head = LibGit2.head(git_repo)
         git_branch = LibGit2.shortname(git_head)
+        git_clean = !LibGit2.isdirty(git_repo)
 
         if myid() == 1
-            println("Running on branch: $git_branch, commit: $git_commit")
+            println("Running on branch: $git_branch, commit: $git_commit, clean: $git_clean")
             flush(stdout)
         end
-        return git_branch, git_commit
+        return git_branch, git_commit, git_clean
     catch e
         if myid() == 1
             println("Local folder is not a git repository. Not recording git branch and commit.")
             flush(stdout)
         end
-        return "", ""
+        return "", "", false
     end
 end
 # this will be reexecuted each time utils.jl is included somewhere, this is not inherently a problem
 # but it is a symptom of the fact that the include situation is a bit tangled
-git_branch, git_commit = initalize_git(dirname(Base.active_project()) * "/")
+git_branch, git_commit, git_clean = initalize_git(dirname(Base.active_project()) * "/")
 
 # bad_dark_pix_bits = 2^2 + 2^4 #+ 2^5; temporarily remove 2^5 from badlist for now
 bad_dark_pix_bits = 2^1 + 2^2 + 2^4


### PR DESCRIPTION
add support for making sure the git commit hash actually tells you what code you are running by checking if the git directory is clean.