### PR TITLE
Fix safe_jldsave to insert git info into the metadata of all files

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using ApogeeReduction, Test, Random, Statistics
 # The file structure in test roughly mirrors that of src.  Each file is included below.
 @testset verbose=true "ApogeeReduction.jl" begin
     include("ar3D.jl")
+    include("safe_jldsave.jl")
 end

--- a/test/safe_jldsave.jl
+++ b/test/safe_jldsave.jl
@@ -1,0 +1,21 @@
+using HDF5
+using ApogeeReduction: safe_jldsave
+
+@testset "safe_jldsave" begin
+    path = tempdir() * "/test.h5"
+    metadata = Dict{String, Any}()
+
+    data = ones(Int, 10, 10)
+
+    safe_jldsave(path, metadata; data)
+
+    git_branch = h5read(path, "metadata/git_branch")
+    git_commit = h5read(path, "metadata/git_commit")
+    git_clean = h5read(path, "metadata/git_clean")
+
+    @test git_branch == ApogeeReduction.git_branch
+    @test git_commit == ApogeeReduction.git_commit
+    @test git_clean == ApogeeReduction.git_clean
+
+    # would be good to test here that the h5 file is "clean"
+end


### PR DESCRIPTION
We were doing this at some point, but it accidentally got removed. I've fixed that and added a test so it won't happen again.