### PR TITLE
guard against lamp-off cases in trace fitting

### DIFF
--- a/scripts/cal/make_traces_from_flats.jl
+++ b/scripts/cal/make_traces_from_flats.jl
@@ -58,7 +58,7 @@ end
     using JLD2, ProgressMeter, ArgParse, Glob, StatsBase, ParallelDataTransfer
     using ApogeeReduction
     using ApogeeReduction: get_cal_file, get_fpi_guide_fiberID, get_fps_plate_divide, trace_extract,
-                           safe_jldsave, trace_plots, bad_pix_bits, check_file
+                           safe_jldsave, trace_plots, bad_pix_bits, check_file, nanzeropercentile
 end
 
 @passobj 1 workers() parg # make it available to all workers
@@ -100,6 +100,14 @@ end
         sname = split(split(split(fname, "/")[end], ".h5")[1], "_")
         fnameType, teleloc, mjdloc, expnumloc, chiploc, exptype = sname[(end - 5):end]
         mjdfps2plate = get_fps_plate_divide(teleloc)
+        #thresholds are ~20% of typical value (of smallest flux chip, and smallest flux from dome vs quartz) from days when lamps were on
+        if teleloc == "apo"
+            flux_med_thresh = 16
+            flux_68p_thresh = 40
+        elseif teleloc == "lco"
+            flux_med_thresh = 10
+            flux_68p_thresh = 10
+        end
         
         savename = joinpath(parg["trace_dir"], "$(flat_type)_flats", "$(mjdloc)", "$(flat_type)Trace_$(teleloc)_$(mjdloc)_$(expnumloc)_$(chiploc).h5")
         if check_file(savename, mode = checkpoint_mode)
@@ -111,13 +119,21 @@ end
         ivar_image = f["ivarimage"][1:N_XPIX, 1:N_XPIX]
         pix_bitmask_image = f["pix_bitmask"][1:N_XPIX, 1:N_XPIX]
         close(f)
+
+        good_pixels = ((pix_bitmask_image .& bad_pix_bits) .== 0)
+        flux_summary = nanzeropercentile(image_data[good_pixels],percent_vec=[16,50,84])
+        flux_med = flux_summary[2]
+        flux_68p = 0.5*(flux_summary[3]-flux_summary[1])
+        if flux_68p < flux_68p_thresh
+            @warn "File $(fname) (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2))) was skipped for appearing to have the lamp turned off."
+            return nothing
+        end
     
         (med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib, max_prof_fib,
         all_y_prof, all_y_prof_deriv) = ApogeeReduction.get_default_trace_hyperparams(teleloc, chiploc, profile_path = joinpath(proj_path, "data"), plot_path = joinpath(parg["trace_dir"], "plots/"))
     
         #    trace_params, trace_param_covs = trace_extract(
         #        image_data, ivar_image, teleloc, mjdloc, chiploc, expidloc; good_pixels = nothing)
-        good_pixels = ((pix_bitmask_image .& bad_pix_bits) .== 0)
         trace_params,
         trace_param_covs = trace_extract(
             image_data, ivar_image, teleloc, mjdloc, expnumloc, chiploc,
@@ -140,6 +156,10 @@ if !parg["slack_quiet"]
     if length(unique_mjds) > 1
         thread("$(parg["flat_type"])Flat Traces for $(parg["tele"]) $(chips) from SJD $(minimum(unique_mjds)) to $(maximum(unique_mjds))")
         for (filename, heights_widths_path) in zip(flist, plot_paths)
+            if isnothing(heights_widths_path)
+                thread("WARNING: File $(filename) was skipped for appearing to have the lamp turned off.")
+                continue
+            end
             thread("Here is the median flux and width per fiber for $(filename)", heights_widths_path)
         end
     else

--- a/src/arclamp_peaks.jl
+++ b/src/arclamp_peaks.jl
@@ -720,6 +720,9 @@ function get_initial_arclamp_peaks(flux, ivar)
     good_max_inds = ((local_max_waves .>= (n_offset + 1)) .&
                      (local_max_waves .<= n_pixels - (n_offset + 1)))
     good_y_vals = local_max_waves[good_max_inds]
+    if size(good_y_vals,1) == 0
+        return [], zeros((0, 4)), zeros((0, 4, 4))
+    end
 
     #fit 1D gaussians to each identified peak, using offset_inds around each peak
     offset_inds = range(start = -4, stop = 4, step = 1)

--- a/src/arclamp_peaks.jl
+++ b/src/arclamp_peaks.jl
@@ -892,8 +892,16 @@ function get_and_save_arclamp_peaks(fname; checkpoint_mode = "commit_same")
 
     max_peaks = 0
     for i in 1:size(pout, 1)
-        max_peaks = max(max_peaks, length(pout[i][1]))
+		curr_n_peaks = length(pout[i][1])
+		if curr_n_peaks == 0
+			@warn "File $(fname) FiberIndex $(i) found no useful arclamp peaks"
+		end
+        max_peaks = max(max_peaks, curr_n_peaks)
     end
+	if max_peaks == 0
+		@warn "File $(fname) found no useful arclamp peaks in ANY fibers."
+		return nothing
+	end
 
     n_params = size(pout[1][2], 2)
     fpi_trace_centers = zeros(

--- a/src/fileNameHandling.jl
+++ b/src/fileNameHandling.jl
@@ -15,7 +15,7 @@ function build_raw_path(tele, chip, mjd, exposure_id; cluster = "sdss", suppress
     base = if cluster == "sdss"
         "/uufs/chpc.utah.edu/common/home/sdss/sdsswork/data/apogee" #the raw data is NOT version dependent
     elseif cluster == "cca"
-        "/mnt/ceph/users/sdssv/APOGEE/raw"
+        "/mnt/ceph/users/sdssv/raw/APOGEE"
     else
         !suppress_warning && warn("Unknown cluster, interpreting as a path: $cluster")
         cluster

--- a/src/traceExtract_GH.jl
+++ b/src/traceExtract_GH.jl
@@ -209,19 +209,24 @@ function pdf_func_mult(x, mean, width, fiber_inds, x_prof_min, x_prof_max_ind, n
         min_prof_fib, all_y_prof, all_y_prof_deriv; return_deriv = false)
     x_bins = x[:, 1] .+ range(-0.5, size(x, 2))'
     z_bins = (x_bins .- mean) ./ width
+    bad_params = (.!isfinite.(z_bins))
+    bad_peaks = dropdims(any(bad_params,dims=2),dims = 2)
+    mults = ones(size(bad_peaks))
+    mults[bad_peaks] .= NaN
+    z_bins[bad_params] .= 0.0    
     z_ints = ceil.(Int, round.((z_bins .- x_prof_min) .* n_sub)) .+ 1
     z_ints = clamp.(z_ints, 1, x_prof_max_ind)
 
     fib_ints = (fiber_inds .- min_prof_fib) .+ 1 .+ zeros(Int, size(z_ints))
     pdfs = diff(getindex.(Ref(all_y_prof), fib_ints, z_ints), dims = 2)
     if !return_deriv
-        return pdfs
+        return pdfs .* mults
     else
         dpdf_dmus = diff(getindex.(Ref(all_y_prof_deriv), fib_ints, z_ints), dims = 2) .*
                     (-1 ./ width)
         dpdf_dsigs = diff(
             getindex.(Ref(all_y_prof_deriv), fib_ints, z_ints) .* (-1 .* z_bins ./ width), dims = 2)
-        return pdfs, dpdf_dmus, dpdf_dsigs
+        return pdfs .* mults, dpdf_dmus .* mults, dpdf_dsigs .* mults
     end
 end
 
@@ -418,8 +423,8 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
     prior_center_to_fiber_func = linear_interpolation(
         prior_trace_pos, prior_fiber_inds, extrapolation_bc = Line())
 
+    good_pixels .= good_pixels .& (ivar_image .> 0) .& (isfinite.(image_data))
     noise_image = 1 ./ sqrt.(ivar_image)
-    good_pixels .= good_pixels .& (ivar_image .> 0)
     #     n_center_cols = 100 # +/- n_cols to use from middle to sum to find peaks
 
     # Cutout image in x direction
@@ -577,6 +582,8 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
         n_iter = 10, return_cov = false,
         use_first_guess_heights = false, max_center_move = 2,
         min_widths = 0.5, max_widths = 2.0)
+    good_results = dropdims(all(isfinite.(new_params),dims=2),dims=2)
+    new_params = new_params[good_results,:]
 
     med_flux = nanmedian(new_params[:, 1])
     good_throughput_fibers = (new_params[:, 1] ./ med_flux) .> 0.2
@@ -615,6 +622,8 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
         n_iter = 10, return_cov = false,
         use_first_guess_heights = false, max_center_move = 2,
         min_widths = 0.5, max_widths = 2.0)
+    good_results = dropdims(all(isfinite.(new_params),dims=2),dims=2)
+    new_params = new_params[good_results,:]
 
     curr_best_params = copy(new_params)
 
@@ -779,6 +788,8 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
         use_first_guess_heights = true, max_center_move = 3,
         min_widths = 0.8 .* first_guess_params[:, 3],
         max_widths = 1.2 .* first_guess_params[:, 3])
+#    good_results = dropdims(all(isfinite.(new_params),dims=2),dims=2)
+#    new_params = new_params[good_results,:]
 
     #save the middle-of-detector best fit parameters for first guess
     best_fit_ave_params = copy(new_params)
@@ -917,7 +928,7 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
     curr_fiber_inds = clamp.(range(1, size(best_fit_ave_params, 1)), min_prof_fib, max_prof_fib)
 
     med_flux = nanmedian(best_fit_ave_params[:, 1], 1)
-    good_throughput_fibers = (best_fit_ave_params[:, 1] ./ med_flux) .> low_throughput_thresh
+    good_throughput_fibers = ((best_fit_ave_params[:, 1] ./ med_flux) .> low_throughput_thresh) .& (isfinite.(best_fit_ave_params[:,2]))
     low_throughput_fibers = findall(.!good_throughput_fibers)
 
     x_inds = axes(image_data, 1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,7 +17,7 @@ function initalize_git(git_dir)
         git_clean = !LibGit2.isdirty(git_repo)
 
         if myid() == 1
-            println("Running on branch: $git_branch, commit: $git_commit, clean: $git_clean, clean: $git_clean")
+            println("Running on branch: $git_branch, commit: $git_commit, clean: $git_clean")
             flush(stdout)
         end
         return git_branch, git_commit, git_clean, git_clean


### PR DESCRIPTION
Added some logic to test flux 68% region of dome and quartz flats to see if the flat lamps were turned on (i.e. reject if current 68% region is <20% of the expected value).

Also added some guards against Int(NaN) cases, although this mostly pushed the issue further along in the code. These NaN cases have only occurred (so far, to my knowledge) when the dome/quartz lamps are accidentally left off, so this case shouldn't be triggered now with the turned-off-lamp masking.

In the future, almanac should be automatically removing the lamp-off images from the analysis entirely.
