### PR TITLE
CCA Plots and LCO Traces

### DIFF
--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -48,11 +48,13 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.imagetyp .== "$(uppercasefirst(parg["flat_type"]))Flat") 
+        good_exp = (df.imagetyp .== "$(uppercasefirst(parg["flat_type"]))Flat") .&
+                   (df.lampune .== "F") .& (df.lampthar .== "F")
         if parg["flat_type"] == "dome"
-            good_exp .&= (df.nreadInt .> 3)
+            good_exp .&= (df.nreadInt .> 3) .& (df.lampqrtz .== "F")
         else
-            good_exp .&= (df.nreadInt .>= 3)
+            #i.e. quartz
+            good_exp .&= (df.nreadInt .>= 3) .& (df.lampqrtz .== "T")
         end
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc

--- a/scripts/cal/make_traces_from_flats.jl
+++ b/scripts/cal/make_traces_from_flats.jl
@@ -130,7 +130,7 @@ end
         flux_med = flux_summary[2]
         flux_68p = 0.5*(flux_summary[3]-flux_summary[1])
         if flux_68p < flux_68p_thresh
-            @warn "File $(fname) (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2))) was skipped for appearing to have the lamp turned off."
+            @warn "File $(fname) (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2))) was skipped for appearing to have the lamp turned off. Used $(round(sum(good_pixels)/length(good_pixels)*100,digits=2))% of the pixels for this calculation."
             return nothing
         end
     
@@ -150,7 +150,7 @@ end
                 good_pixels = good_pixels, median_trace_pos_path = joinpath(proj_path, "data"))
         catch
             println("Trace fitting failed for $(fname)")
-            println("Flux info is (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2)))")
+            println("Flux info is (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2)), percent_good_pixels = $(round(sum(good_pixels)/length(good_pixels)*100,digits=2))%)")
             trace_params, trace_param_covs = trace_extract(
                 image_data, ivar_image, teleloc, mjdloc, expnumloc, chiploc,
                 med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv;

--- a/scripts/cal/make_traces_from_flats.jl
+++ b/scripts/cal/make_traces_from_flats.jl
@@ -156,6 +156,13 @@ end
                 med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv;
                 good_pixels = good_pixels, median_trace_pos_path = joinpath(proj_path, "data"))
         end
+
+        if size(trace_params,1) == 0
+	    # KEVIN should look at what is going on with these weird LCO early MJD (e.g. 57801) cases more closely in future
+            @warn "File $(fname) (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2)), percent_good_pixels = $(round(sum(good_pixels)/length(good_pixels)*100,digits=2))%) was skipped for not finding any good throughput fibers."
+            return nothing
+	end
+
         regularized_trace_params = regularize_trace(trace_params)
 
         mkpath(dirname(savename))

--- a/scripts/daily/generate_dashboard.jl
+++ b/scripts/daily/generate_dashboard.jl
@@ -408,8 +408,10 @@ function main()
     # post a link to slack
     # the link to the dashboard is relative to the current directory
     dir = abspath(joinpath(pwd(), parg["outdir"], "plots", string(mjd), "dashboard.html"))
-    url = "<"*replace(replace(replace(dir, 
+    url = "<"*replace(replace(replace(replace(replace(dir, 
         "/uufs/chpc.utah.edu/common/home/sdss42/" => "https://data.sdss5.org/sas/"),
+        "/mnt/ceph/users/sdssv/work/kmckinnon/" => "https://users.flatironinstitute.org/~kmckinnon/$(ENV["SLACK_TOKEN"])/sdsswork/"),
+        "/mnt/ceph/users/sdssv/work/" => "https://users.flatironinstitute.org/~kmckinnon/$(ENV["SLACK_TOKEN"])/"),
         "/mnt/ceph/users/sdssv/work/asaydjari/" => "https://users.flatironinstitute.org/~asaydjari/$(ENV["SLACK_TOKEN"])/sdsswork/"),
         "/mnt/ceph/users/sdssv/work/" => "https://users.flatironinstitute.org/~asaydjari/$(ENV["SLACK_TOKEN"])/"
     )*"|here>"

--- a/scripts/daily/plot_all.jl
+++ b/scripts/daily/plot_all.jl
@@ -307,7 +307,7 @@ for mjd_ind in 1:size(unique_mjds, 1)
         all1DObjectSkyDither, all1DObject_expid_strings, mjd, tele)
 
     outname = parg["outdir"] *
-              "/apred/$(unique_mjds[mjd_ind])/waveCalFPI_$(parg["tele"])_$(unique_mjds[mjd_ind])_ARCLAMP.h5"
+              "/apred/$(unique_mjds[mjd_ind])/waveCalFPI_$(parg["tele"])_$(unique_mjds[mjd_ind])_arclamp.h5"
     if !isfile(outname)
         println("Could not find nightly FPI wavelength solution at $(outname)")
         continue

--- a/scripts/monitor/wave_soln.jl
+++ b/scripts/monitor/wave_soln.jl
@@ -41,7 +41,7 @@ end
 function summarize_wave_solns(tele_loc,mjd_list,plotdir;
 			      dporder=2)
 
-    fname_loc = joinpath(parg["outdir"], "apred/$(mjd_list[1])/waveCalFPI_$(tele_loc)_$(mjd_list[1])_ARCLAMP.h5") 
+    fname_loc = joinpath(parg["outdir"], "apred/$(mjd_list[1])/waveCalFPI_$(tele_loc)_$(mjd_list[1])_arclamp.h5") 
     linParams = load(fname_loc, "linParams")
     nlParams = load(fname_loc, "nlParams")
     ditherParams = load(fname_loc, "ditherParams")
@@ -76,7 +76,7 @@ function summarize_wave_solns(tele_loc,mjd_list,plotdir;
     all_ditherCorr_linParams[1,:,:] .= comp_linParams
 
     for (mjd_ind,mjd_loc) in enumerate(mjd_list)
-        fname_loc = joinpath(parg["outdir"], "apred/$(mjd_loc)/waveCalFPI_$(tele_loc)_$(mjd_loc)_ARCLAMP.h5") 
+        fname_loc = joinpath(parg["outdir"], "apred/$(mjd_loc)/waveCalFPI_$(tele_loc)_$(mjd_loc)_arclamp.h5") 
 
         all_linParams[mjd_ind,:,:] .= load(fname_loc, "linParams")
         all_nlParams[mjd_ind,:,:] .= load(fname_loc, "nlParams")
@@ -350,7 +350,7 @@ good_mjds = zeros(Bool, size(poss_mjds,1))
 for tele in ["apo", "lco"]
     good_mjds[:] .= false
     for (mjd_ind,mjd) in enumerate(poss_mjds)
-        if isfile(joinpath(parg["outdir"], "apred/$(mjd)/waveCalFPI_$(tele)_$(mjd)_ARCLAMP.h5"))
+        if isfile(joinpath(parg["outdir"], "apred/$(mjd)/waveCalFPI_$(tele)_$(mjd)_arclamp.h5"))
             good_mjds[mjd_ind] = true
         end
     end


### PR DESCRIPTION
Fixed it so FPI wavelength solution plots at CCA should make it to the dashboard ("ARCLAMP" to "arclamp" in expected filename).

Also protected against a few strange cases in early LCO data (e.g. 57801) where trace parameter fitting as failing. Might want to come back to this in the future to look at the 2D images that are causing the failure, but this fix should get us through to the next stage of a bulk run.