### PR TITLE
fix plotting paths

### DIFF
--- a/scripts/daily/generate_dashboard.jl
+++ b/scripts/daily/generate_dashboard.jl
@@ -408,13 +408,13 @@ function main()
     # post a link to slack
     # the link to the dashboard is relative to the current directory
     dir = abspath(joinpath(pwd(), parg["outdir"], "plots", string(mjd), "dashboard.html"))
-    url = "<"*replace(replace(replace(replace(replace(dir, 
+    url = "<"*replace(replace(replace(replace(dir, 
         "/uufs/chpc.utah.edu/common/home/sdss42/" => "https://data.sdss5.org/sas/"),
         "/mnt/ceph/users/sdssv/work/kmckinnon/" => "https://users.flatironinstitute.org/~kmckinnon/$(ENV["SLACK_TOKEN"])/sdsswork/"),
-        "/mnt/ceph/users/sdssv/work/" => "https://users.flatironinstitute.org/~kmckinnon/$(ENV["SLACK_TOKEN"])/"),
         "/mnt/ceph/users/sdssv/work/asaydjari/" => "https://users.flatironinstitute.org/~asaydjari/$(ENV["SLACK_TOKEN"])/sdsswork/"),
         "/mnt/ceph/users/sdssv/work/" => "https://users.flatironinstitute.org/~asaydjari/$(ENV["SLACK_TOKEN"])/"
     )*"|here>"
+
     thread = SlackThread()
     msg = "The reduction plots dashboard for SJD $(mjd) has been generated and is available at: $url"
     thread(msg)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts Slack dashboard link generation to include asaydjari path mappings and update the default /mnt/ceph users work path mapping.
> 
> - **Slack link generation** (`scripts/daily/generate_dashboard.jl`):
>   - Add path mappings for `'/mnt/ceph/users/sdssv/work/asaydjari/'` and set default `'/mnt/ceph/users/sdssv/work/'` to asaydjari URLs.
>   - Retain mappings for `'/uufs/chpc.utah.edu/common/home/sdss42/'` and kmckinnon-specific paths; keep Slack-formatted link output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93081febb52c0848f967972e6bf067012651a4e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->