### PR TITLE
Almanac strict data types

### DIFF
--- a/pipeline_2d_1d.jl
+++ b/pipeline_2d_1d.jl
@@ -306,7 +306,7 @@ if parg["relFlux"]
         end
         function get_1d_name_ARCLAMP_partial(expid)
             if (df.imagetyp[expid] == "ArcLamp") &
-               ((df.lampthar[expid] == "T") | (df.lampune[expid] == "T"))
+               ((df.lamp_thar[expid] == 1) | (df.lamp_une[expid] == 1))
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"
             else
@@ -314,8 +314,8 @@ if parg["relFlux"]
             end
         end
         function get_1d_name_FPI_partial(expid)
-            if (df.imagetyp[expid] == "ArcLamp") & (df.lampthar[expid] == "F") &
-               (df.lampune[expid] == "F")
+            if (df.imagetyp[expid] == "ArcLamp") & (df.lamp_thar[expid] == 0) &
+               (df.lamp_une[expid] == 0)
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"
             else

--- a/pipeline_2d_1d.jl
+++ b/pipeline_2d_1d.jl
@@ -297,7 +297,7 @@ if parg["relFlux"]
         df = read_almanac_exp_df(
             joinpath(parg["outdir"], "almanac/$(parg["runname"]).h5"), parg["tele"], mjd)
         function get_1d_name_partial(expid)
-            if df.imagetyp[expid] == "Object"
+            if df.image_type[expid] == "object"
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"
             else
@@ -305,7 +305,7 @@ if parg["relFlux"]
             end
         end
         function get_1d_name_ARCLAMP_partial(expid)
-            if (df.imagetyp[expid] == "ArcLamp") &
+            if (df.image_type[expid] == "arclamp") &
                ((df.lamp_thar[expid] == 1) | (df.lamp_une[expid] == 1))
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"
@@ -314,7 +314,7 @@ if parg["relFlux"]
             end
         end
         function get_1d_name_FPI_partial(expid)
-            if (df.imagetyp[expid] == "ArcLamp") & (df.lamp_thar[expid] == 0) &
+            if (df.image_type[expid] == "arclamp") & (df.lamp_thar[expid] == 0) &
                (df.lamp_une[expid] == 0)
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"

--- a/scripts/bulk/make_runlist_all.jl
+++ b/scripts/bulk/make_runlist_all.jl
@@ -53,8 +53,8 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.nreadInt .> 3) .|
-                   ((df.imagetyp .== "QuartzFlat") .& (df.nreadInt .== 3))
+        good_exp = (df.n_read .> 3) .|
+                   ((df.imagetyp .== "QuartzFlat") .& (df.n_read .== 3))
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)

--- a/scripts/bulk/make_runlist_all.jl
+++ b/scripts/bulk/make_runlist_all.jl
@@ -3,7 +3,7 @@
 using Pkg;
 Pkg.instantiate();
 using HDF5, JLD2, ArgParse, DataFrames
-using ApogeeReduction: read_almanac_exp_df, safe_jldsave, long_expid_to_short
+using ApogeeReduction: read_almanac_exp_df, safe_jldsave
 
 ## Parse command line arguments
 function parse_commandline()
@@ -31,7 +31,7 @@ end
 parg = parse_commandline()
 
 mjdexp_list = Int[]
-expid_list = Int[]
+expid_list = String[]
 dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
@@ -55,10 +55,11 @@ for tele in tele2do
         df = read_almanac_exp_df(f, tele, tstmjd)
         good_exp = (df.n_read .> 3) .|
                    ((df.image_type .== "quartzflat") .& (df.n_read .== 3))
+        good_exp .&= (df.chip_flags .== 7)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)
-            push!(expid_list, long_expid_to_short(tstmjd_int,df.exposure[dfindx]))
+            push!(expid_list, df.exposure_string[dfindx])
             push!(dfindx_list, dfindx)
             push!(tele_list, tele)
         end

--- a/scripts/bulk/make_runlist_all.jl
+++ b/scripts/bulk/make_runlist_all.jl
@@ -58,7 +58,7 @@ for tele in tele2do
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)
-            push!(expid_list, long_expid_to_short(tstmjd_int,df.exposure_int[dfindx]))
+            push!(expid_list, long_expid_to_short(tstmjd_int,df.exposure[dfindx]))
             push!(dfindx_list, dfindx)
             push!(tele_list, tele)
         end

--- a/scripts/bulk/make_runlist_all.jl
+++ b/scripts/bulk/make_runlist_all.jl
@@ -54,7 +54,7 @@ for tele in tele2do
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
         good_exp = (df.n_read .> 3) .|
-                   ((df.imagetyp .== "QuartzFlat") .& (df.n_read .== 3))
+                   ((df.image_type .== "quartzflat") .& (df.n_read .== 3))
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)

--- a/scripts/cal/make_relFlux.jl
+++ b/scripts/cal/make_relFlux.jl
@@ -181,7 +181,7 @@ if length(all1Da) > 0
         @everywhere begin
             function plot_relFlux(fname)
                 sname = split(split(split(fname, "/")[end], ".h5")[1], "_")
-                fnameType, tele, mjd, expnum, chiploc, imagetyp, cartid = sname[(end - 6):end]
+                fnameType, tele, mjd, expnum, chiploc, image_type, cartid = sname[(end - 6):end]
 
                 xvec = if tele == "apo"
                     1:300

--- a/scripts/cal/make_relFlux.jl
+++ b/scripts/cal/make_relFlux.jl
@@ -93,10 +93,10 @@ else
 end
 unique_mjds = unique(mjd_list)
 
-expid_list = if parg["runlist"] != ""
-    load(parg["runlist"], "expid")
+dfindx_list = if parg["runlist"] != ""
+    load(parg["runlist"], "dfindx")
 else
-    [parg["expid"]]
+    [parg["dfindx"]]
 end
 
 
@@ -107,11 +107,11 @@ for tele in unique_teles
         if count(mskMJD) > 0
             df = read_almanac_exp_df(
                 joinpath(parg["trace_dir"], "almanac/$(parg["runname"]).h5"), tele, mjd)
-            function get_1d_name_partial(expid)
+            function get_1d_name_partial(dfindx)
                 joinpath(parg["trace_dir"], "apredrelflux/$(mjd)",
-                    get_1d_name(expid, df, cal = true) * ".h5")
+                    get_1d_name(dfindx, df, cal = true) * ".h5")
             end
-            file_list = get_1d_name_partial.(expid_list[mskMJD])
+            file_list = get_1d_name_partial.(dfindx_list[mskMJD])
             append!(all1Da, file_list)
         end
     end
@@ -133,7 +133,7 @@ if length(all1Da) > 0
             for mjd in unique_mjds
                 mskMJD = (mjd_list .== mjd) .& (tele_list .== tele)
                 if count(mskMJD) > 0
-                    f["$(tele)/$(mjd)"] = expid_list[mskMJD]
+                    f["$(tele)/$(mjd)"] = dfindx_list[mskMJD]
                 end
             end
         end

--- a/scripts/cal/make_runlist_darks.jl
+++ b/scripts/cal/make_runlist_darks.jl
@@ -48,7 +48,7 @@ for tele in tele2do
         for dfindx in dfindx_list_loc
             if dfindx > 1 && df.imagetyp[dfindx - 1] == "Dark"
                 push!(mjdexp_list, tstmjd_int)
-                push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure_int[dfindx]))
+                push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
                 push!(dfindx_list, dfindx)
                 push!(tele_list, tele)
             end

--- a/scripts/cal/make_runlist_darks.jl
+++ b/scripts/cal/make_runlist_darks.jl
@@ -43,10 +43,10 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.imagetyp .== "Dark") .& (df.n_read .> 29)
+        good_exp = (df.image_type .== "dark") .& (df.n_read .> 29)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
-            if dfindx > 1 && df.imagetyp[dfindx - 1] == "Dark"
+            if dfindx > 1 && df.image_type[dfindx - 1] == "dark"
                 push!(mjdexp_list, tstmjd_int)
                 push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
                 push!(dfindx_list, dfindx)

--- a/scripts/cal/make_runlist_darks.jl
+++ b/scripts/cal/make_runlist_darks.jl
@@ -1,7 +1,7 @@
 using Pkg;
 Pkg.instantiate();
 using HDF5, ArgParse, DataFrames, JLD2
-using ApogeeReduction: safe_jldsave, read_almanac_exp_df, long_expid_to_short
+using ApogeeReduction: safe_jldsave, read_almanac_exp_df
 
 ## Parse command line arguments
 function parse_commandline()

--- a/scripts/cal/make_runlist_darks.jl
+++ b/scripts/cal/make_runlist_darks.jl
@@ -43,7 +43,7 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.imagetyp .== "Dark") .& (df.nreadInt .> 29)
+        good_exp = (df.imagetyp .== "Dark") .& (df.n_read .> 29)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             if dfindx > 1 && df.imagetyp[dfindx - 1] == "Dark"

--- a/scripts/cal/make_runlist_darks.jl
+++ b/scripts/cal/make_runlist_darks.jl
@@ -29,7 +29,7 @@ end
 parg = parse_commandline()
 
 mjdexp_list = Int[]
-expid_list = Int[]
+expid_list = String[]
 dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
@@ -43,12 +43,12 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.image_type .== "dark") .& (df.n_read .> 29)
+        good_exp = (df.image_type .== "dark") .& (df.n_read .> 29) .& (df.chip_flags .== 7)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             if dfindx > 1 && df.image_type[dfindx - 1] == "dark"
                 push!(mjdexp_list, tstmjd_int)
-                push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
+                push!(expid_list, df.exposure_string[dfindx])
                 push!(dfindx_list, dfindx)
                 push!(tele_list, tele)
             end

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -34,7 +34,7 @@ end
 parg = parse_commandline()
 
 mjdexp_list = Int[]
-expid_list = Int[]
+expid_list = String[]
 dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
@@ -49,7 +49,7 @@ for tele in tele2do
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
         good_exp = (df.image_type .== "$(parg["flat_type"])flat") .&
-                   (df.lamp_une .== 0) .& (df.lamp_thar .== 0)
+                   (df.lamp_une .== 0) .& (df.lamp_thar .== 0) .& (df.chip_flags .== 7)
         if parg["flat_type"] == "dome"
             good_exp .&= (df.n_read .> 3) .& (df.lamp_quartz .== 0)
         else
@@ -59,7 +59,7 @@ for tele in tele2do
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)
-            push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
+            push!(expid_list, df.exposure_string[dfindx])
             push!(dfindx_list, dfindx)
             push!(tele_list, tele)
         end

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -59,7 +59,7 @@ for tele in tele2do
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)
-            push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure_int[dfindx]))
+            push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
             push!(dfindx_list, dfindx)
             push!(tele_list, tele)
         end

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -51,10 +51,10 @@ for tele in tele2do
         good_exp = (df.imagetyp .== "$(uppercasefirst(parg["flat_type"]))Flat") .&
                    (df.lampune .== "F") .& (df.lampthar .== "F")
         if parg["flat_type"] == "dome"
-            good_exp .&= (df.nreadInt .> 3) .& (df.lampqrtz .== "F")
+            good_exp .&= (df.n_read .> 3) .& (df.lampqrtz .== "F")
         else
             #i.e. quartz
-            good_exp .&= (df.nreadInt .>= 3) .& (df.lampqrtz .== "T")
+            good_exp .&= (df.n_read .>= 3) .& (df.lampqrtz .== "T")
         end
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -49,12 +49,12 @@ for tele in tele2do
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
         good_exp = (df.imagetyp .== "$(uppercasefirst(parg["flat_type"]))Flat") .&
-                   (df.lampune .== "F") .& (df.lampthar .== "F")
+                   (df.lamp_une .== 0) .& (df.lamp_thar .== 0)
         if parg["flat_type"] == "dome"
-            good_exp .&= (df.n_read .> 3) .& (df.lampqrtz .== "F")
+            good_exp .&= (df.n_read .> 3) .& (df.lamp_qrtz .== 0)
         else
             #i.e. quartz
-            good_exp .&= (df.n_read .>= 3) .& (df.lampqrtz .== "T")
+            good_exp .&= (df.n_read .>= 3) .& (df.lamp_qrtz .== 1)
         end
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -48,7 +48,7 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.imagetyp .== "$(uppercasefirst(parg["flat_type"]))Flat") .&
+        good_exp = (df.image_type .== "$(parg["flat_type"])flat") .&
                    (df.lamp_une .== 0) .& (df.lamp_thar .== 0)
         if parg["flat_type"] == "dome"
             good_exp .&= (df.n_read .> 3) .& (df.lamp_qrtz .== 0)

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -1,7 +1,7 @@
 using Pkg;
 Pkg.instantiate();
 using JLD2, ArgParse, DataFrames, HDF5
-using ApogeeReduction: safe_jldsave, read_almanac_exp_df, long_expid_to_short
+using ApogeeReduction: safe_jldsave, read_almanac_exp_df
 
 ## Parse command line arguments
 function parse_commandline()

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -51,10 +51,10 @@ for tele in tele2do
         good_exp = (df.image_type .== "$(parg["flat_type"])flat") .&
                    (df.lamp_une .== 0) .& (df.lamp_thar .== 0)
         if parg["flat_type"] == "dome"
-            good_exp .&= (df.n_read .> 3) .& (df.lamp_qrtz .== 0)
+            good_exp .&= (df.n_read .> 3) .& (df.lamp_quartz .== 0)
         else
             #i.e. quartz
-            good_exp .&= (df.n_read .>= 3) .& (df.lamp_qrtz .== 1)
+            good_exp .&= (df.n_read .>= 3) .& (df.lamp_quartz .== 1)
         end
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc

--- a/scripts/cal/make_runlist_internal_flats.jl
+++ b/scripts/cal/make_runlist_internal_flats.jl
@@ -47,7 +47,7 @@ for tele in tele2do
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)
-            push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure_int[dfindx]))
+            push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
             push!(dfindx_list, dfindx)
             push!(tele_list, tele)
         end

--- a/scripts/cal/make_runlist_internal_flats.jl
+++ b/scripts/cal/make_runlist_internal_flats.jl
@@ -29,7 +29,7 @@ end
 parg = parse_commandline()
 
 mjdexp_list = Int[]
-expid_list = Int[]
+expid_list = String[]
 dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
@@ -43,11 +43,11 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.image_type .== "internalflat") .& (df.n_read .> 3)
+        good_exp = (df.image_type .== "internalflat") .& (df.n_read .> 3) .& (df.chip_flags .== 7)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)
-            push!(expid_list, long_expid_to_short(tstmjd_int, df.exposure[dfindx]))
+            push!(expid_list, df.exposure_string[dfindx])
             push!(dfindx_list, dfindx)
             push!(tele_list, tele)
         end

--- a/scripts/cal/make_runlist_internal_flats.jl
+++ b/scripts/cal/make_runlist_internal_flats.jl
@@ -43,7 +43,7 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.imagetyp .== "InternalFlat") .& (df.nreadInt .> 3)
+        good_exp = (df.imagetyp .== "InternalFlat") .& (df.n_read .> 3)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)

--- a/scripts/cal/make_runlist_internal_flats.jl
+++ b/scripts/cal/make_runlist_internal_flats.jl
@@ -43,7 +43,7 @@ for tele in tele2do
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)
-        good_exp = (df.imagetyp .== "InternalFlat") .& (df.n_read .> 3)
+        good_exp = (df.image_type .== "internalflat") .& (df.n_read .> 3)
         dfindx_list_loc = findall(good_exp)
         for dfindx in dfindx_list_loc
             push!(mjdexp_list, tstmjd_int)

--- a/scripts/cal/make_runlist_internal_flats.jl
+++ b/scripts/cal/make_runlist_internal_flats.jl
@@ -1,7 +1,7 @@
 using Pkg;
 Pkg.instantiate();
 using JLD2, ArgParse, DataFrames, HDF5
-using ApogeeReduction: safe_jldsave, read_almanac_exp_df, long_expid_to_short
+using ApogeeReduction: safe_jldsave, read_almanac_exp_df
 
 ## Parse command line arguments
 function parse_commandline()

--- a/scripts/cal/make_stack_darks.jl
+++ b/scripts/cal/make_stack_darks.jl
@@ -194,7 +194,7 @@ let #each frame
     if length(flist) < 500
         for (indx, fname) in enumerate(flist)
             sname = split(split(split(fname, "/")[end],".h5")[1], "_")
-            fnameType, teleloc, mjdloc, expnumloc, chiploc, imagetyp = sname[(end - 5):end]
+            fnameType, teleloc, mjdloc, expnumloc, chiploc, image_type = sname[(end - 5):end]
             
             f = jldopen(fname)
             temp_im = f["dimage"]
@@ -235,7 +235,7 @@ let # each frame residuals
     if length(flist) < 500
         for (indx, fname) in enumerate(flist)
             sname = split(split(split(fname, "/")[end],".h5")[1], "_")
-            fnameType, teleloc, mjdloc, expnumloc, chiploc, imagetyp = sname[(end - 5):end]
+            fnameType, teleloc, mjdloc, expnumloc, chiploc, image_type = sname[(end - 5):end]
             f = jldopen(fname)
             temp_im = f["dimage"]
             close(f)

--- a/scripts/cal/make_stack_flats.jl
+++ b/scripts/cal/make_stack_flats.jl
@@ -110,7 +110,7 @@ bad_pix_dark = (dark_pix_bitmask[5:2044, 5:2044] .& bad_dark_pix_bits .!= 0);
 desc = "Stacking flats for $(parg["tele"]) $(chip) from $(parg["mjd-start"]) to $(parg["mjd-end"])"
 @showprogress desc=desc for (indx, fname) in enumerate(flist)
     sname = split(split(split(fname, "/")[end],".h5")[1], "_")
-    fnameType, tele, mjdloc, expnumloc, chiploc, imagetyp = sname[(end - 5):end]
+    fnameType, tele, mjdloc, expnumloc, chiploc, image_type = sname[(end - 5):end]
 
     floc = jldopen(fname)
     temp_im = floc["dimage"]
@@ -235,7 +235,7 @@ else
             # Post each frame individually since there are few frames
             for (i, fname) in enumerate(flist)
                 sname = split(split(split(fname, "/")[end],".h5")[1], "_")
-                fnameType, teleloc, mjdloc, expnumloc, chiploc, imagetyp = sname[(end - 5):end]
+                fnameType, teleloc, mjdloc, expnumloc, chiploc, image_type = sname[(end - 5):end]
             
                 fig = Figure(size = (1200, 800), fontsize = 24)
                 ax = Axis(fig[1, 1])
@@ -286,7 +286,7 @@ else
                 resize_to_layout!(fig)
 
                 sname = split(flist[i], "_")
-                fnameType, teleloc, mjdloc, expnumloc, chiploc, imagetyp = sname[(end - 5):end]
+                fnameType, teleloc, mjdloc, expnumloc, chiploc, image_type = sname[(end - 5):end]
 
                 text!(ax,
                     0.5, 1.05,

--- a/scripts/cal/make_traces_from_flats.jl
+++ b/scripts/cal/make_traces_from_flats.jl
@@ -86,13 +86,13 @@ end
     end
     mjd_list = load(parg["runlist"], "mjd")
     unique_mjds = unique(mjd_list)
-    expid_list = load(parg["runlist"], "expid")
+    dfindx_list = load(parg["runlist"], "dfindx")
     cal_flist = String[] # all cal files for FIRST CHIP
     for tele in unique_teles
         expid2do = findall(tele_list .== tele)
         for chip in chips
             for i in expid2do
-                push!(cal_flist, get_cal_file(parg["trace_dir"], tele_list[i], mjd_list[i], expid_list[i], chip, "$(uppercase(parg["flat_type"]))FLAT", use_cal = true))
+                push!(cal_flist, get_cal_file(parg["trace_dir"], tele_list[i], mjd_list[i], dfindx_list[i], chip, "$(parg["flat_type"])flat", use_cal = true))
             end
         end
     end

--- a/scripts/cal/make_traces_from_flats.jl
+++ b/scripts/cal/make_traces_from_flats.jl
@@ -103,7 +103,7 @@ end
 
     function make_traces(fname, flat_type; checkpoint_mode = "commit_same")
         sname = split(split(split(fname, "/")[end], ".h5")[1], "_")
-        fnameType, teleloc, mjdloc, expnumloc, chiploc, imagetyp = sname[(end - 5):end]
+        fnameType, teleloc, mjdloc, expnumloc, chiploc, image_type = sname[(end - 5):end]
         mjdfps2plate = get_fps_plate_divide(teleloc)
         #thresholds are ~20% of typical value (of smallest flux chip, and smallest flux from dome vs quartz) from days when lamps were on
         if teleloc == "apo"

--- a/scripts/daily/plot_all.jl
+++ b/scripts/daily/plot_all.jl
@@ -116,7 +116,7 @@ for mjd in unique_mjds
         end
         function get_1d_name_ARCLAMP_partial(expid)
             if (df.imagetyp[expid] == "ArcLamp") &
-               ((df.lampthar[expid] == "T") | (df.lampune[expid] == "T"))
+               ((df.lamp_thar[expid] == 1) | (df.lamp_une[expid] == 1))
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"
             else
@@ -124,8 +124,8 @@ for mjd in unique_mjds
             end
         end
         function get_1d_name_FPI_partial(expid)
-            if (df.imagetyp[expid] == "ArcLamp") & (df.lampthar[expid] == "F") &
-               (df.lampune[expid] == "F")
+            if (df.imagetyp[expid] == "ArcLamp") & (df.lamp_thar[expid] == 0) &
+               (df.lamp_une[expid] == 0)
                 return parg["outdir"] * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *
                        ".h5"
             else

--- a/scripts/daily/plot_all.jl
+++ b/scripts/daily/plot_all.jl
@@ -564,16 +564,6 @@ end
 list2Dexp = []
 for mjd in unique_mjds
     df = read_almanac_exp_df(parg["outdir"] * "almanac/$(parg["runname"]).h5", parg["tele"], mjd)
-    df.exposure_int = if typeof(df.exposure) <: Array{Int}
-        df.exposure
-    else
-        parse.(Int, df.exposure)
-    end
-    df.exposure_str = if typeof(df.exposure) <: Array{String}
-        df.exposure
-    else
-        lpad.(string.(df.exposure), 8, "0")
-    end
 
     function get_2d_name_partial(expid)
         parg["outdir"] * "/apred/$(mjd)/" *

--- a/scripts/daily/plot_all.jl
+++ b/scripts/daily/plot_all.jl
@@ -640,7 +640,7 @@ allimage_type = convert.(String, map(x -> split(split(split(x, "/")[end], ".")[1
 # Define custom sorting order for exposure types
 function get_image_type_priority(image_type::AbstractString)
     priority_map = Dict(
-        "object" => 1
+        "object" => 1,
         "twilightflat" => 2,
         "domeflat" => 3,
         "internalflat" => 4,
@@ -673,6 +673,7 @@ for chip in chips2do
             for exp_fname in all1D[msk_image_type]
                 sname = split(split(split(exp_fname, "/")[end], ".h5")[1], "_")
                 fnameType, tele, mjd, expnum, chiploc, image_type = sname[(end - 5):end]
+                dfindx = parse(Int, expnum)
 
                 flux_1d = load(exp_fname, "flux_1d")
                 mask_1d = load(exp_fname, "mask_1d")
@@ -680,7 +681,7 @@ for chip in chips2do
                 # msk_loc = (mask_1d .&
                 #         (bad_pix_bits + bad_1d_failed_extract + bad_1d_no_good_pix + bad_1d_neff) .== 0)
 
-                fibtargDict = get_fibTargDict(f, tele, mjd, expnum)
+                fibtargDict = get_fibTargDict(f, tele, mjd, dfindx)
                 sample_fibers = sample(rng, 1:300, 3, replace = false)
                 for fib in sample_fibers
                     fibType = fibtargDict[fib]
@@ -864,6 +865,7 @@ for image_type2plot in sorted_image_types
         for exp_fname in all1Da[msk_image_type]
             sname = split(split(split(exp_fname, "/")[end], ".h5")[1], "_")
             fnameType, tele, mjd, expnum, chiploc, image_type = sname[(end - 5):end]
+            dfindx = parse(Int, expnum)
             # expuni_fname = replace(
             #     replace(exp_fname, "ar1D" => "ar1Duni"), "_$(FIRST_CHIP)_" => "_")
             # outflux = load(expuni_fname, "flux_1d")
@@ -875,7 +877,7 @@ for image_type2plot in sorted_image_types
             # need to switch this back when the masking is updated
             # msk_loc = (outmsk .& bad_pix_bits .== 0)
 
-            fibtargDict = get_fibTargDict(f, tele, mjd, expnum)
+            fibtargDict = get_fibTargDict(f, tele, mjd, dfindx)
             sample_fibers = sample(rng, 1:300, 3, replace = false)
             for fib in sample_fibers
                 # plot_1d_uni(fib, fibtargDict, outflux, outmsk, "ar1Duni",

--- a/scripts/daily/plot_all.jl
+++ b/scripts/daily/plot_all.jl
@@ -640,12 +640,13 @@ allimage_type = convert.(String, map(x -> split(split(split(x, "/")[end], ".")[1
 # Define custom sorting order for exposure types
 function get_image_type_priority(image_type::AbstractString)
     priority_map = Dict(
-        "object" => 1,
-        "domeflat" => 2,
-        "internalflat" => 3,
-        "quartzflat" => 4,
-        "dark" => 5,
-        "arclamp" => 6
+        "object" => 1
+        "twilightflat" => 2,
+        "domeflat" => 3,
+        "internalflat" => 4,
+        "quartzflat" => 5,
+        "dark" => 6,
+        "arclamp" => 7
     )
     return get(priority_map, image_type, 999)  # Unknown types get high number
 end

--- a/scripts/daily/plot_all.jl
+++ b/scripts/daily/plot_all.jl
@@ -5,7 +5,7 @@ using JLD2, ProgressMeter, ArgParse, Glob, StatsBase, Random, HDF5, DataFrames
 
 using ApogeeReduction
 using ApogeeReduction: read_almanac_exp_df, get_1d_name, get_fibTargDict, nanzeropercentile,
-                       nanzeromedian, parseCartID, bad_pix_bits, fiberIndx2fiberID,
+                       nanzeromedian, bad_pix_bits, fiberIndx2fiberID,
                        logUniWaveAPOGEE, isnanorzero
 
 proj_path = dirname(Base.active_project()) * "/"
@@ -564,7 +564,6 @@ end
 list2Dexp = []
 for mjd in unique_mjds
     df = read_almanac_exp_df(parg["outdir"] * "almanac/$(parg["runname"]).h5", parg["tele"], mjd)
-    df.cartidInt = parseCartID.(df.cartid)
     df.exposure_int = if typeof(df.exposure) <: Array{Int}
         df.exposure
     else

--- a/scripts/daily/run_all.sh
+++ b/scripts/daily/run_all.sh
@@ -82,7 +82,7 @@ print_elapsed_time() {
     LAST_TIME=$current_seconds
 }
 
-updates the sdsscore submodules (which has to be done from that directory)
+# updates the sdsscore submodules (which has to be done from that directory)
 if $update_sdsscore && { [ ! -f "$almanac_file" ] || $almanac_clobber_mode; }; then
     print_elapsed_time "Updating sdsscore"
     ORIG_PWD=$(pwd)
@@ -96,7 +96,7 @@ fi
 if [ ! -f "$almanac_file" ] || $almanac_clobber_mode; then
     print_elapsed_time "Running Almanac"
     # activate shared almanac (uv python) environment
-    source /mnt/home/sdssv/uv_env/almanac_v0p2p4/bin/activate 
+    source /mnt/home/sdssv/uv_env/almanac_v0p2p5/bin/activate 
     #  need to have .ssh/config setup for mwm and a pass_file that is chmod 400
     sshpass -f ~/pass_file ssh -f -N -L 63333:operations.sdss.org:5432 mwm
 

--- a/scripts/daily/run_all.sh
+++ b/scripts/daily/run_all.sh
@@ -154,14 +154,14 @@ if [ "$run_2d_only" != "true" ]; then
     print_elapsed_time "Generating plot page for web viewing"
     julia +$julia_version --project=$base_dir $base_dir/scripts/daily/generate_dashboard.jl --mjd $mjd --outdir $outdir
 
-    ## arMADGICS
-    if [ -d ${path2arMADGICS} ]; then
-        print_elapsed_time "Running arMADGICS"
-        julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}pipeline.jl --redux_base $outdir --almanac_file $almanac_file --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
+    # ## arMADGICS
+    # if [ -d ${path2arMADGICS} ]; then
+    #     print_elapsed_time "Running arMADGICS"
+    #     julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}pipeline.jl --redux_base $outdir --almanac_file $almanac_file --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
 
-        print_elapsed_time "Running arMADGICS Workup"
-        julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}workup.jl --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
-    fi
+    #     print_elapsed_time "Running arMADGICS Workup"
+    #     julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}workup.jl --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
+    # fi
 fi
 
 print_elapsed_time "Job Completed"

--- a/scripts/daily/run_all.sh
+++ b/scripts/daily/run_all.sh
@@ -96,7 +96,7 @@ fi
 if [ ! -f "$almanac_file" ] || $almanac_clobber_mode; then
     print_elapsed_time "Running Almanac"
     # activate shared almanac (uv python) environment
-    source /mnt/home/sdssv/uv_env/almanac_v0p1p11/bin/activate 
+    source /mnt/home/sdssv/uv_env/almanac_v0p2p2/bin/activate 
     #  need to have .ssh/config setup for mwm and a pass_file that is chmod 400
     sshpass -f ~/pass_file ssh -f -N -L 63333:operations.sdss.org:5432 mwm
 

--- a/scripts/daily/run_all.sh
+++ b/scripts/daily/run_all.sh
@@ -82,7 +82,7 @@ print_elapsed_time() {
     LAST_TIME=$current_seconds
 }
 
-# updates the sdsscore submodules (which has to be done from that directory)
+updates the sdsscore submodules (which has to be done from that directory)
 if $update_sdsscore && { [ ! -f "$almanac_file" ] || $almanac_clobber_mode; }; then
     print_elapsed_time "Updating sdsscore"
     ORIG_PWD=$(pwd)
@@ -96,7 +96,7 @@ fi
 if [ ! -f "$almanac_file" ] || $almanac_clobber_mode; then
     print_elapsed_time "Running Almanac"
     # activate shared almanac (uv python) environment
-    source /mnt/home/sdssv/uv_env/almanac_v0p2p2/bin/activate 
+    source /mnt/home/sdssv/uv_env/almanac_v0p2p4/bin/activate 
     #  need to have .ssh/config setup for mwm and a pass_file that is chmod 400
     sshpass -f ~/pass_file ssh -f -N -L 63333:operations.sdss.org:5432 mwm
 
@@ -154,14 +154,14 @@ if [ "$run_2d_only" != "true" ]; then
     print_elapsed_time "Generating plot page for web viewing"
     julia +$julia_version --project=$base_dir $base_dir/scripts/daily/generate_dashboard.jl --mjd $mjd --outdir $outdir
 
-    # ## arMADGICS
-    # if [ -d ${path2arMADGICS} ]; then
-    #     print_elapsed_time "Running arMADGICS"
-    #     julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}pipeline.jl --redux_base $outdir --almanac_file $almanac_file --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
+    ## arMADGICS
+    if [ -d ${path2arMADGICS} ]; then
+        print_elapsed_time "Running arMADGICS"
+        julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}pipeline.jl --redux_base $outdir --almanac_file $almanac_file --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
 
-    #     print_elapsed_time "Running arMADGICS Workup"
-    #     julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}workup.jl --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
-    # fi
+        print_elapsed_time "Running arMADGICS Workup"
+        julia +$julia_version --project=${path2arMADGICS} ${path2arMADGICS}workup.jl --outdir ${outdir}arMADGICS/raw_${tele}_${mjd}/
+    fi
 fi
 
 print_elapsed_time "Job Completed"

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -309,10 +309,10 @@ function get_fibTargDict(f, tele, mjd, expnum)
     # TODO Andrew thinks the fibers with category "" might be serendipitous targets
 
     mjdfps2plate = get_fps_plate_divide(tele)
-    configName, configIdCol, target_type_col = if parse(Int, mjd) > mjdfps2plate
-        "fps", "configid", "category"
+    configIdCol, target_type_col = if parse(Int, mjd) > mjdfps2plate
+        "configid", "category"
     else
-        "plates", "plateid", "target_type" # TODO should this be source_type?
+        "plateid", "target_type" # TODO should this be source_type?
     end
 
     df_exp = read_almanac_exp_df(f, tele, mjd)
@@ -326,12 +326,12 @@ function get_fibTargDict(f, tele, mjd, expnum)
 
     fibtargDict = if exposure_info.image_type == "object"
         try
-            df_fib = DataFrame(read(f["$(tele)/$(mjd)/fibers/$(configName)/$(configid)"]))
+            df_fib = DataFrame(read(f["$(tele)/$(mjd)/fibers/$(configid)"]))
             # normalizes all column names to lowercase
             rename!(df_fib, lowercase.(names(df_fib)))
 
             # limit to only the APOGEE fiber/hole information
-            df_fib = if configName == "fps"
+            df_fib = if configIdCol == "configid"
                 df_fib[df_fib[!, "fiber_type"].=="APOGEE",:]
             else
                 df_fib
@@ -341,7 +341,7 @@ function get_fibTargDict(f, tele, mjd, expnum)
                 if t in keys(fiber_type_names)
                     fiber_type_names[t]
                 else
-                    # @warn "Unknown fiber type for $(tele)/$(mjd)/fibers/$(configName)/$(configid): $(repr(t))"
+                    # @warn "Unknown fiber type for $(tele)/$(mjd)/fibers/$(configid): $(repr(t))"
                     "fiberTypeFail"
                 end
             end
@@ -358,7 +358,7 @@ function get_fibTargDict(f, tele, mjd, expnum)
             Dict(fiberID2fiberIndx.(fibernumvec) .=> fiber_types)
         catch e
             rethrow(e)
-            @warn "Failed to get any fiber type information for $(tele)/$(mjd)/fibers/$(configName)/$(configid) (exposure $(exposure_id)). Returning fiberTypeFail for all fibers."
+            @warn "Failed to get any fiber type information for $(tele)/$(mjd)/fibers/$(configid) (exposure $(exposure_id)). Returning fiberTypeFail for all fibers."
             show(e)
             Dict(1:300 .=> "fiberTypeFail")
         end

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -401,7 +401,7 @@ function get_fluxing_file(dfalmanac, parent_dir, tele, mjd, expnum, runname; flu
         dfalmanac[(dfalmanac.mjd .== parse(Int, mjd)) .& (dfalmanac.observatory .== tele), :],
         :exposure)
     expIndex = findfirst(df_mjd.exposure_int .== exposure_id)
-    cartId = df_mjd.cartidInt[expIndex]
+    cartId = df_mjd.cart_id[expIndex]
 
     expid_num = parse(Int, last(expnum, 4)) #this is silly because we translate right back
     valid_flats4fluxing_fname = joinpath(parent_dir, "almanac/valid_domeflats4fluxing_$(runname).h5")
@@ -443,18 +443,18 @@ function get_fluxing_file(dfalmanac, parent_dir, tele, mjd, expnum, runname; flu
 
     valid_before = if isnothing(expIndex_before)
         0
-    elseif all(df_mjd.cartidInt[expIndex_before:expIndex] .== cartId)
+    elseif all(df_mjd.cart_id[expIndex_before:expIndex] .== cartId)
 	1
-    elseif !isnothing(expIndex_before) & (df_mjd.cartidInt[expIndex_before] .== cartId)
+    elseif !isnothing(expIndex_before) & (df_mjd.cart_id[expIndex_before] .== cartId)
         2
     else
         0
     end
     valid_after = if isnothing(expIndex_after) 
         0
-    elseif all(df_mjd.cartidInt[expIndex:expIndex_after] .== cartId)
+    elseif all(df_mjd.cart_id[expIndex:expIndex_after] .== cartId)
         1
-    elseif !isnothing(expIndex_after) & (df_mjd.cartidInt[expIndex_after] .== cartId)
+    elseif !isnothing(expIndex_after) & (df_mjd.cart_id[expIndex_after] .== cartId)
         2
     else
         0

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -343,17 +343,12 @@ function get_fibTargDict(f, tele, mjd, dfindx)
                     "fiberTypeFail"
                 end
             end
-            fibernum_col = df_fib[!, "fiber_id"]
-            # println(typeof(fibernum_col))
-            fibernumvec = if fibernum_col isa AbstractVector{<:Integer}
-                fibernum_col
-            elseif fibernum_col isa AbstractVector{<:String}
-                parse.(Int, fibernum_col)
-            else
-                @warn "Fiber numbers are neither integers or strings"
-                fibernum_col
-            end
-            Dict(fiberID2fiberIndx.(fibernumvec) .=> fiber_types)
+            fibernumvec = df_fib[!, "fiber_id"]
+
+            #this is a Hack and Andy Casey will replace this very very soon
+            fiber_types_full = repeat(["fiberTypeFail"], N_FIBERS)
+            fiber_types_full[fiberID2fiberIndx.(fibernumvec)] .= fiber_types
+            Dict(1:N_FIBERS .=> fiber_types_full)
         catch e
             rethrow(e)
             @warn "Failed to get any fiber type information for $(tele)/$(mjd)/fibers/$(config_id) (exposure $(dfindx)). Returning fiberTypeFail for all fibers."

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -309,10 +309,10 @@ function get_fibTargDict(f, tele, mjd, expnum)
     # TODO Andrew thinks the fibers with category "" might be serendipitous targets
 
     mjdfps2plate = get_fps_plate_divide(tele)
-    configIdCol, target_type_col = if parse(Int, mjd) > mjdfps2plate
-        "configid", "category"
+    configIdCol = if parse(Int, mjd) > mjdfps2plate
+        "configid"
     else
-        "plateid", "target_type" # TODO should this be source_type?
+        "plateid"
     end
 
     df_exp = read_almanac_exp_df(f, tele, mjd)
@@ -337,7 +337,7 @@ function get_fibTargDict(f, tele, mjd, expnum)
                 df_fib
             end
 
-            fiber_types = map(df_fib[!, target_type_col]) do t
+            fiber_types = map(df_fib[!, "category"]) do t
                 if t in keys(fiber_type_names)
                     fiber_type_names[t]
                 else
@@ -432,7 +432,7 @@ function get_fluxing_file(dfalmanac, parent_dir, tele, mjd, expnum, runname; flu
     else
         0
     end
-    valid_after = if isnothing(expIndex_after) 
+    valid_after = if isnothing(expIndex_after)
         0
     elseif all(df_mjd.cart_id[expIndex:expIndex_after] .== cartId)
         1
@@ -555,7 +555,7 @@ function reinterp_spectra(fname, roughwave_dict; backupWaveSoln = nothing, check
             wave_stack[(1:N_XPIX) .+ (3 - chipind) * N_XPIX, :] .= chipWaveSoln[end:-1:1, :, chipind]
         catch
             println((typeof(wave_stack), typeof(N_XPIX), typeof(chipind), typeof(chipWaveSoln),fname, mjd_int, typeof(backupWaveSoln), typeof(backupWaveSoln)))
-        end 
+        end
         wave_stack[(1:N_XPIX) .+ (3 - chipind) * N_XPIX, :] .= chipWaveSoln[end:-1:1, :, chipind]
         trace_center_stack[(1:N_XPIX) .+ (3 - chipind) * N_XPIX, :] .= extract_trace_centers[
             end:-1:1, :]

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -317,11 +317,11 @@ function get_fibTargDict(f, tele, mjd, expnum)
 
     df_exp = read_almanac_exp_df(f, tele, mjd)
 
-    if !(exposure_id in df_exp.exposure_str)
+    if !(exposure_id in df_exp.exposure_string)
         @warn "Exposure $(exposure_id) not found in $(tele)/$(mjd)/exposures"
         return Dict(1:300 .=> "fiberTypeFail")
     end
-    exposure_info = df_exp[findfirst(df_exp[!, "exposure_str"] .== exposure_id), :]
+    exposure_info = df_exp[findfirst(df_exp[!, "exposure_string"] .== exposure_id), :]
     configid = exposure_info[configIdCol]
 
     fibtargDict = if exposure_info.imagetyp == "Object"
@@ -400,7 +400,7 @@ function get_fluxing_file(dfalmanac, parent_dir, tele, mjd, expnum, runname; flu
     df_mjd = sort(
         dfalmanac[(dfalmanac.mjd .== parse(Int, mjd)) .& (dfalmanac.observatory .== tele), :],
         :exposure)
-    expIndex = findfirst(df_mjd.exposure_int .== exposure_id)
+    expIndex = findfirst(df_mjd.exposure .== exposure_id)
     cartId = df_mjd.cart_id[expIndex]
 
     expid_num = parse(Int, last(expnum, 4)) #this is silly because we translate right back
@@ -429,7 +429,7 @@ function get_fluxing_file(dfalmanac, parent_dir, tele, mjd, expnum, runname; flu
     if expid_num in cal_expid_list
         #the current files is one of the dome flats that has a relfluxing file
         return 2^0,get_fluxing_file_name(
-            parent_dir, tele, mjd, last(df_mjd.exposure_str[expIndex], 4), fluxing_chip, cartId)
+            parent_dir, tele, mjd, last(df_mjd.exposure_string[expIndex], 4), fluxing_chip, cartId)
     end
 
     expIndex_before = findlast(cal_expid_list .< expid_num)
@@ -462,17 +462,17 @@ function get_fluxing_file(dfalmanac, parent_dir, tele, mjd, expnum, runname; flu
 
     if valid_before == 1
         return 2^0,get_fluxing_file_name(
-            parent_dir, tele, mjd, last(df_mjd.exposure_str[expIndex_before], 4), fluxing_chip, cartId)
+            parent_dir, tele, mjd, last(df_mjd.exposure_string[expIndex_before], 4), fluxing_chip, cartId)
     elseif valid_after == 1
         return 2^0,get_fluxing_file_name(
-            parent_dir, tele, mjd, last(df_mjd.exposure_str[expIndex_after], 4), fluxing_chip, cartId)
+            parent_dir, tele, mjd, last(df_mjd.exposure_string[expIndex_after], 4), fluxing_chip, cartId)
         # any of the cases below here we could consider using a global file
     elseif valid_before == 2
         return 2^1,get_fluxing_file_name(
-            parent_dir, tele, mjd, last(df_mjd.exposure_str[expIndex_before], 4), fluxing_chip, cartId)
+            parent_dir, tele, mjd, last(df_mjd.exposure_string[expIndex_before], 4), fluxing_chip, cartId)
     elseif valid_after == 2
         return 2^1,get_fluxing_file_name(
-            parent_dir, tele, mjd, last(df_mjd.exposure_str[expIndex_after], 4), fluxing_chip, cartId)
+            parent_dir, tele, mjd, last(df_mjd.exposure_string[expIndex_after], 4), fluxing_chip, cartId)
     else
         return 2^2,nothing
     end

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -324,20 +324,11 @@ function get_fibTargDict(f, tele, mjd, expnum)
     exposure_info = df_exp[findfirst(df_exp[!, "exposure_string"] .== exposure_id), :]
     configid = exposure_info[configIdCol]
 
-    fibtargDict = if exposure_info.imagetyp == "Object"
+    fibtargDict = if exposure_info.image_type == "object"
         try
             df_fib = DataFrame(read(f["$(tele)/$(mjd)/fibers/$(configName)/$(configid)"]))
             # normalizes all column names to lowercase
             rename!(df_fib, lowercase.(names(df_fib)))
-
-            # sometimes the fiber id column is called "fiber_id" and sometimes it is called "fiberid"
-            fiberid_col = if "fiber_id" in names(df_fib)
-                "fiber_id"
-            elseif "fiberid" in names(df_fib)
-                "fiberid"
-            else
-                error("fiber_id or fiberid column not found in $(configName)/$(configid). Available columns: $(names(df_fib))")
-            end
 
             # limit to only the APOGEE fiber/hole information
             df_fib = if configName == "fps"
@@ -363,7 +354,7 @@ function get_fibTargDict(f, tele, mjd, expnum)
                     "fiberTypeFail"
                 end
             end
-            fibernum_col = df_fib[!, fiberid_col]
+            fibernum_col = df_fib[!, "fiber_id"]
             # println(typeof(fibernum_col))
             fibernumvec = if fibernum_col isa AbstractVector{<:Integer}
                 fibernum_col
@@ -487,7 +478,7 @@ function reinterp_spectra(fname, roughwave_dict; backupWaveSoln = nothing, check
     end
 
     sname = split(split(split(fname, "/")[end], ".h5")[1], "_")
-    fnameType, tele, mjd, expnum, chip, imagetyp = sname[(end - 5):end]
+    fnameType, tele, mjd, expnum, chip, image_type = sname[(end - 5):end]
     mjd_int = parse(Int, mjd)
 
     # could shift this to a preallocation step
@@ -655,7 +646,7 @@ function process_1D(fname;
         profile_path = "./data/",
         plot_path = "../outdir/$(sjd)/plots/")
     sname = split(split(split(fname, "/")[end], ".h5")[1], "_")
-    fnameType, tele, mjd, expnum, chip, imagetyp = sname[(end - 5):end]
+    fnameType, tele, mjd, expnum, chip, image_type = sname[(end - 5):end]
 
     # this seems annoying to load so often if we know we are doing a daily... need to ponder
     traceFname = outdir * "apred/$(mjd)/traceMain_$(tele)_$(mjd)_$(chip).h5"

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -332,16 +332,7 @@ function get_fibTargDict(f, tele, mjd, expnum)
 
             # limit to only the APOGEE fiber/hole information
             df_fib = if configName == "fps"
-                # sometimes the fiber type column is called "fiberType" and sometimes it is called "fibertype"
-                fiberType_col = if "fiberType" in names(df_fib)
-                    "fiberType"
-                elseif "fibertype" in names(df_fib)
-                    "fibertype"
-                else
-                    error("fiberType or fibertype column not found in $(configName)/$(configid). Available columns: $(names(df_fib))")
-                end
-
-                df_fib[df_fib[!, fiberType_col].=="APOGEE",:]
+                df_fib[df_fib[!, "fiber_type"].=="APOGEE",:]
             else
                 df_fib
             end

--- a/src/ar3D.jl
+++ b/src/ar3D.jl
@@ -372,22 +372,22 @@ function process_3D(outdir, runname, tel, mjd, expid, chip,
     end
 
     df = read_almanac_exp_df(joinpath(outdir, "almanac/$(runname).h5"), tel, mjd)
-    #        println(expid,chip,size(df.observatory),size(df.mjd),size(df.exposure_int))
+    #        println(expid,chip,size(df.observatory),size(df.mjd),size(df.exposure))
     # check if chip is in the llist of chips in df.something[expid] (waiting on Andy Casey to update alamanc)
     rawpath = build_raw_path(
-        df.observatory[expid], chip, df.mjd[expid], lpad(df.exposure_int[expid], 8, "0"),
+        df.observatory[expid], chip, df.mjd[expid], df.exposure_string[expid], 
         cluster = cluster, suppress_warning = suppress_warning)
     cartid = df.cart_id[expid]
 
     outfname = join(
         ["ar2D", df.observatory[expid], df.mjd[expid],
-            last(df.exposure_string[expid], 4), chip, lowercase(df.imagetyp[expid])],
+            last(df.exposure_string[expid], 4), chip, lowercase(df.image_type[expid])],
         "_")
     fname = joinpath(outdir, "apred/$(mjd)/" * outfname * ".h5")
 
     outfname3d = join(
         ["ar3Dcal", df.observatory[expid], df.mjd[expid],
-            last(df.exposure_string[expid], 4), chip, lowercase(df.imagetyp[expid])],
+            last(df.exposure_string[expid], 4), chip, lowercase(df.image_type[expid])],
         "_")
     fname3d = joinpath(outdir, "apred/$(mjd)/" * outfname3d * ".h5")
 
@@ -415,10 +415,10 @@ function process_3D(outdir, runname, tel, mjd, expid, chip,
     # override the firstind and extractMethod in special cases
     # we drop the first read, but might need to adjust for the few read cases (2,3,4,5)
     firstind,
-    extractMethod = if ((df.imagetyp[expid] == "DomeFlat") &
+    extractMethod = if ((df.image_type[expid] == "DomeFlat") &
                         (df.observatory[expid] == "apo")) # NREAD 5, and lamp gets shutoff too soon (needs to be DCS)
         2, "dcs"
-    elseif ((df.imagetyp[expid] == "QuartzFlat") & (nread_total == 3))
+    elseif ((df.image_type[expid] == "QuartzFlat") & (nread_total == 3))
         2, "dcs"
     elseif (nread_total == 3)
         #catch some weird cases (like nreads=3 with Darks)
@@ -486,7 +486,7 @@ function process_3D(outdir, runname, tel, mjd, expid, chip,
         "mjd_mid_exposure_precise" => value(mjd_mid_exposure_precise),
         "mjd_mid_exposure" => value(mjd_mid_exposure)
     )
-    # need to clean up imagetyp to account for FPI versus ARCLAMP
+    # need to clean up image_type to account for FPI versus ARCLAMP
     safe_jldsave(fname, metadata; dimage, ivarimage, chisqimage, CRimage, last_unsaturated)
 
     if save3dcal
@@ -502,7 +502,7 @@ end
 # come back to tuning the chi2perdofcut once more rigorously establish noise model
 function process_2Dcal(fname; chi2perdofcut = 100, checkpoint_mode = "commit_same")
     sname = split(split(split(fname, "/")[end], ".h5")[1], "_")
-    fnameType, tele, mjd, expnum, chip, imagetyp = sname[(end - 5):end]
+    fnameType, tele, mjd, expnum, chip, image_type = sname[(end - 5):end]
     outfname = replace(fname, "ar2D" => "ar2Dcal")
     if check_file(outfname, mode = checkpoint_mode)
         return

--- a/src/ar3D.jl
+++ b/src/ar3D.jl
@@ -415,10 +415,10 @@ function process_3D(outdir, runname, tel, mjd, expid, chip,
     # override the firstind and extractMethod in special cases
     # we drop the first read, but might need to adjust for the few read cases (2,3,4,5)
     firstind,
-    extractMethod = if ((df.image_type[expid] == "DomeFlat") &
+    extractMethod = if ((df.image_type[expid] == "domeflat") &
                         (df.observatory[expid] == "apo")) # NREAD 5, and lamp gets shutoff too soon (needs to be DCS)
         2, "dcs"
-    elseif ((df.image_type[expid] == "QuartzFlat") & (nread_total == 3))
+    elseif ((df.image_type[expid] == "quartzflat") & (nread_total == 3))
         2, "dcs"
     elseif (nread_total == 3)
         #catch some weird cases (like nreads=3 with Darks)

--- a/src/ar3D.jl
+++ b/src/ar3D.jl
@@ -381,13 +381,13 @@ function process_3D(outdir, runname, tel, mjd, expid, chip,
 
     outfname = join(
         ["ar2D", df.observatory[expid], df.mjd[expid],
-            last(df.exposure_str[expid], 4), chip, lowercase(df.imagetyp[expid])],
+            last(df.exposure_string[expid], 4), chip, lowercase(df.imagetyp[expid])],
         "_")
     fname = joinpath(outdir, "apred/$(mjd)/" * outfname * ".h5")
 
     outfname3d = join(
         ["ar3Dcal", df.observatory[expid], df.mjd[expid],
-            last(df.exposure_str[expid], 4), chip, lowercase(df.imagetyp[expid])],
+            last(df.exposure_string[expid], 4), chip, lowercase(df.imagetyp[expid])],
         "_")
     fname3d = joinpath(outdir, "apred/$(mjd)/" * outfname3d * ".h5")
 

--- a/src/ar3D.jl
+++ b/src/ar3D.jl
@@ -377,7 +377,7 @@ function process_3D(outdir, runname, tel, mjd, expid, chip,
     rawpath = build_raw_path(
         df.observatory[expid], chip, df.mjd[expid], lpad(df.exposure_int[expid], 8, "0"),
         cluster = cluster, suppress_warning = suppress_warning)
-    cartid = df.cartidInt[expid]
+    cartid = df.cart_id[expid]
 
     outfname = join(
         ["ar2D", df.observatory[expid], df.mjd[expid],

--- a/src/fileNameHandling.jl
+++ b/src/fileNameHandling.jl
@@ -40,28 +40,32 @@ function long_expid_to_short(mjd, expnum)
     return expnum - (mjd - 55562) * 10000
 end
 
-function get_cal_file(parent_dir, tele, mjd, expnum, chip, image_type; use_cal = false)
+function dfindx_fname_format(dfindx)
+    return lpad(dfindx, 4, "0")
+end
+
+function get_cal_file(parent_dir, tele, mjd, dfindx, chip, image_type; use_cal = false)
     if use_cal
         fname_type = "ar2Dcal"
     else
         fname_type = "ar2D"
     end
     return parent_dir *
-           "apred/$(mjd)/$(fname_type)_$(tele)_$(mjd)_$(lpad(expnum, 4, "0"))_$(chip)_$(lowercase(image_type)).h5"
+           "apred/$(mjd)/$(fname_type)_$(tele)_$(mjd)_$(dfindx_fname_format(dfindx))_$(chip)_$(lowercase(image_type)).h5"
 end
 
-function get_fluxing_file_name(parent_dir, tele, mjd, exposure, chip, cartid)
+function get_fluxing_file_name(parent_dir, tele, mjd, dfindx, chip, cartid)
     return parent_dir *
-           "dome_flats/$(mjd)/domeFlux_$(tele)_$(mjd)_$(exposure)_$(chip)_domeflat_$(cartid).h5"
+           "dome_flats/$(mjd)/domeFlux_$(tele)_$(mjd)_$(dfindx_fname_format(dfindx))_$(chip)_domeflat_$(cartid).h5"
 end
 
-function get_1d_name(expid, df; cal = false)
+function get_1d_name(dfindx, df; cal = false)
     fnameType = if cal
         "ar1Dcal"
     else
         "ar1D"
     end
-    return join([fnameType, df.observatory[expid], df.mjd[expid], last(df.exposure_string[expid],4), chipRaw2Redux[df.chip[expid]], lowercase(df.image_type[expid])], "_")
+    return join([fnameType, df.observatory[dfindx], df.mjd[dfindx], dfindx_fname_format(df.exposure[dfindx]), FIRST_CHIP, df.image_type[dfindx]], "_")
 end
 
 function fiberIndx2fiberID(fibindx)

--- a/src/fileNameHandling.jl
+++ b/src/fileNameHandling.jl
@@ -40,14 +40,14 @@ function long_expid_to_short(mjd, expnum)
     return expnum - (mjd - 55562) * 10000
 end
 
-function get_cal_file(parent_dir, tele, mjd, expnum, chip, imagetyp; use_cal = false)
+function get_cal_file(parent_dir, tele, mjd, expnum, chip, image_type; use_cal = false)
     if use_cal
         fname_type = "ar2Dcal"
     else
         fname_type = "ar2D"
     end
     return parent_dir *
-           "apred/$(mjd)/$(fname_type)_$(tele)_$(mjd)_$(lpad(expnum, 4, "0"))_$(chip)_$(lowercase(imagetyp)).h5"
+           "apred/$(mjd)/$(fname_type)_$(tele)_$(mjd)_$(lpad(expnum, 4, "0"))_$(chip)_$(lowercase(image_type)).h5"
 end
 
 function get_fluxing_file_name(parent_dir, tele, mjd, exposure, chip, cartid)
@@ -61,7 +61,7 @@ function get_1d_name(expid, df; cal = false)
     else
         "ar1D"
     end
-    return join([fnameType, df.observatory[expid], df.mjd[expid], last(df.exposure_str[expid],4), chipRaw2Redux[df.chip[expid]], lowercase(df.imagetyp[expid])], "_")
+    return join([fnameType, df.observatory[expid], df.mjd[expid], last(df.exposure_string[expid],4), chipRaw2Redux[df.chip[expid]], lowercase(df.image_type[expid])], "_")
 end
 
 function fiberIndx2fiberID(fibindx)

--- a/src/fileNameHandling.jl
+++ b/src/fileNameHandling.jl
@@ -30,16 +30,6 @@ function build_raw_path(tele, chip, mjd, exposure_id; cluster = "sdss", suppress
     return join([base, tele, mjd, fname], "/")
 end
 
-# both inputs are strings, as is the output
-function short_expid_to_long(mjd, expnum)
-    return lpad(string(parse(Int,mjd) - 55562), 4, "0") * lpad(expnum, 4, "0")
-end
-
-# both inputs are integers, as is the output
-function long_expid_to_short(mjd, expnum)
-    return expnum - (mjd - 55562) * 10000
-end
-
 function dfindx_fname_format(dfindx)
     return lpad(dfindx, 4, "0")
 end

--- a/src/skyline_peaks.jl
+++ b/src/skyline_peaks.jl
@@ -266,7 +266,7 @@ function get_and_save_sky_peaks(fname, roughwave_dict, df_sky_lines; checkpoint_
     end
 
     sname = split(split(fname, "/")[end], "_")
-    fnameType, tele, mjd, expnum, chip, imagetyp = sname[(end - 5):end]
+    fnameType, tele, mjd, expnum, chip, image_type = sname[(end - 5):end]
 
     f = jldopen(fname, "r+")
     flux_1d = f["flux_1d"]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -284,15 +284,15 @@ function modify_saved_dict(filepath::String, dataset_name::String, modifications
             if !haskey(file, dataset_name)
                 error("Dataset '$dataset_name' not found in file '$filepath'")
             end
-            
+
             # Read existing data
             existing_data = read(file, dataset_name)
-            
+
             # Apply modifications
             for (key, value) in modifications
                 existing_data[key] = value
             end
-            
+
             # Remove old dataset_name and write new one
             delete_object(file, dataset_name)
             # add new version of dataset_name group to the file
@@ -372,7 +372,6 @@ function read_almanac_exp_df(fname, tele, mjd)
             DataFrame(read(f["$(tele)/$(mjd)/exposures"]))
         end
     end
-    df.nreadInt = parse.(Int, df.nread)
     df.cartidInt = parseCartID.(df.cartid)
     df.exposure_int = if typeof(df.exposure) <: Array{Int}
         df.exposure

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -348,21 +348,6 @@ function check_file(filename::AbstractString; mode = "commit_same") # mode is "c
     error("Made it past logic or unknown mode: $mode")
 end
 
-function parseCartID(x)
-    if x == "FPS"
-        return 0
-    elseif x == ""
-        return -1
-    elseif typeof(x) <: Union{Int32, Int64}
-        return x
-    elseif typeof(x) == String
-        return parse(Int, x)
-    elseif typeof(x) <: Union{Float32, Float64}
-        return Int(x)
-    else
-        error("Unknown cartid type: $(typeof(x))")
-    end
-end
 
 function read_almanac_exp_df(fname, tele, mjd)
     df = if fname isa HDF5.File
@@ -372,7 +357,6 @@ function read_almanac_exp_df(fname, tele, mjd)
             DataFrame(read(f["$(tele)/$(mjd)/exposures"]))
         end
     end
-    df.cartidInt = parseCartID.(df.cartid)
     df.exposure_int = if typeof(df.exposure) <: Array{Int}
         df.exposure
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -357,15 +357,5 @@ function read_almanac_exp_df(fname, tele, mjd)
             DataFrame(read(f["$(tele)/$(mjd)/exposures"]))
         end
     end
-    df.exposure_int = if typeof(df.exposure) <: Array{Int}
-        df.exposure
-    else
-        parse.(Int, df.exposure)
-    end
-    df.exposure_str = if typeof(df.exposure) <: Array{String}
-        df.exposure
-    else
-        lpad.(string.(df.exposure), 8, "0")
-    end
     return df
 end


### PR DESCRIPTION
Changes made to accommodate new `almanac` strict data types.
 
Field names have changed:
  - nreadInt → n_read (integer type)
  - cartIdInt → cart_id (integer type)
  - exposure_int → exposure (integer type)
  - exposure_str → exposure_string (string type)
  - imagetyp → image_type (lowercase strings: "object", "dark", "arclamp", etc.)

  2. Lamp status fields have changed (Boolean → Integer):
  - lampqrtz, lampune, lampthar → lamp_qrtz, lamp_une, lamp_thar
  - Values changed from "T"/"F" strings to 1/0 integers

  3. Standardized Image Type Values:
  All image types converted to lowercase:
  - "Object" → "object"
  - "Dark" → "dark"
  - "ArcLamp" → "arclamp"
  - "QuartzFlat" → "quartzflat"
  - "DomeFlat" → "domeflat"
  - "InternalFlat" → "internalflat"

  4. Code Cleanup:
  - Removed helper functions like parseCartID() (no longer needed)
  - Eliminated redundant type conversion logic in ar1D.jl and plot_all.jl
  - Simplified fiber path handling (removed "fps"/"plates" distinction in paths)
  - Updated H5 file path from /fibers/XXX/{id} to /fibers/{id}
  
  5. Files Modified:
  - Core pipeline: pipeline_2d_1d.jl, ar1D.jl, ar3D.jl, utils.jl
  - Calibration scripts: All make_*.jl files in scripts/cal/
  - Analysis scripts: plot_all.jl, bulk processing scripts