### PR TITLE
more protection against weird flats and 1d extraction

### DIFF
--- a/scripts/cal/make_traces_from_flats.jl
+++ b/scripts/cal/make_traces_from_flats.jl
@@ -146,20 +146,22 @@ end
         trace_params, trace_param_covs = try
             trace_extract(
                 image_data, ivar_image, teleloc, mjdloc, expnumloc, chiploc,
-                med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv; 
+                med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, 
+		min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv, fname; 
                 good_pixels = good_pixels, median_trace_pos_path = joinpath(proj_path, "data"))
         catch
             println("Trace fitting failed for $(fname)")
             println("Flux info is (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2)), percent_good_pixels = $(round(sum(good_pixels)/length(good_pixels)*100,digits=2))%)")
             trace_params, trace_param_covs = trace_extract(
                 image_data, ivar_image, teleloc, mjdloc, expnumloc, chiploc,
-                med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv;
+                med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, 
+		min_prof_fib, max_prof_fib, all_y_prof, all_y_prof_deriv, fname;
                 good_pixels = good_pixels, median_trace_pos_path = joinpath(proj_path, "data"))
         end
 
         if size(trace_params,1) == 0
 	    # KEVIN should look at what is going on with these weird LCO early MJD (e.g. 57801) cases more closely in future
-            @warn "File $(fname) (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2)), percent_good_pixels = $(round(sum(good_pixels)/length(good_pixels)*100,digits=2))%) was skipped for not finding any good throughput fibers."
+            @warn "File $(fname) (med_flux = $(round(flux_med,digits=2)), 68% interval = $(round(flux_68p,digits=2)), percent_good_pixels = $(round(sum(good_pixels)/length(good_pixels)*100,digits=2))%) was skipped for not having the correct amount of traces."
             return nothing
 	end
 

--- a/src/traceExtract_GH.jl
+++ b/src/traceExtract_GH.jl
@@ -409,7 +409,7 @@ Returns: trace centers, widths, and heights, and their covariances.
 """
 function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
         med_center_to_fiber_func, x_prof_min, x_prof_max_ind, n_sub, min_prof_fib,
-        max_prof_fib, all_y_prof, all_y_prof_deriv;
+        max_prof_fib, all_y_prof, all_y_prof_deriv, flat_fname;
         good_pixels = ones(Bool, size(image_data)), mid = 1025, n_center_cols = 100, verbose = false,
         low_throughput_thresh = 0.05, median_trace_pos_path = "./data/")
 
@@ -954,11 +954,16 @@ function trace_extract(image_data, ivar_image, tele, mjd, expid, chip,
 
     verbose && println("$(tele_string) Final number of good peaks:", size(best_fit_ave_params))
 
+    n_detected_peaks = size(best_fit_ave_params,1)
     best_fit_ave_params = best_fit_ave_params[good_throughput_fibers, :]
     curr_fiber_inds = curr_fiber_inds[good_throughput_fibers]
 
     verbose && println("$(tele_string) Final number of good throughput peaks:", size(best_fit_ave_params))
     if size(best_fit_ave_params,1) == 0
+        @warn "Skipping trace fitting of $(flat_fname) because 0 traces were found to have detectable flux."
+        return [],[]
+    elseif size(best_fit_ave_params,1) != N_FIBERS
+        @warn "Skipping trace fitting of $(flat_fname) because $(n_detected_peaks) traces were found instead of the expected $(N_FIBERS)"
         return [],[]
     end
 


### PR DESCRIPTION
Warning for cases where the number of traces is not 300, with good warning printouts to track down the files later. Not sure why this is happening, but it is likely another weird edge case of a bad flat file (maybe mislabeled image type?). 

For the ar1D extractions, put in a bit more logic to protect against traces that start to go off the top or bottom of the detector. 