### PR TITLE
Bulk run 2025 11 22

### DIFF
--- a/Manifest-v1.11.toml
+++ b/Manifest-v1.11.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.0"
+julia_version = "1.11.6"
 manifest_format = "2.0"
-project_hash = "05dece0ffd6807f7cf4b4f3f9e228e0595da30db"
+project_hash = "d1c5af73bf3f19dd693c59d018b7b2bdd1698b23"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -226,9 +226,9 @@ version = "0.4.1"
 
 [[deps.ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
-git-tree-sha1 = "26ec26c98ae1453c692efded2b17e15125a5bea1"
+git-tree-sha1 = "b0fd3f56fa442f81e0a47815c92245acfaaa4e34"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.28.0"
+version = "3.31.0"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -1077,6 +1077,12 @@ git-tree-sha1 = "f02b56007b064fbfddb4c9cd60161b6dd0f40df3"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 version = "1.1.0"
 
+[[deps.LowRankOps]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "b524cd9671735260596239b930884d9acfa976d3"
+uuid = "0ea32739-31af-43e6-82ee-ebe6dcf00a6f"
+version = "0.1.1"
+
 [[deps.MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
 git-tree-sha1 = "5de60bc6cb3899cd318d80d627560fae2e2d99ae"
@@ -1244,7 +1250,7 @@ version = "3.2.4+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+2"
+version = "0.8.5+0"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
@@ -2037,7 +2043,7 @@ uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.59.0+0"
 
 [[deps.oneTBB_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
 git-tree-sha1 = "d5a767a3bb77135a99e433afe0eb14cd7f6914c3"
 uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
 version = "2022.0.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ Jackknife = "133c4774-c510-5f25-b650-129312f89f69"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LowRankOps = "0ea32739-31af-43e6-82ee-ebe6dcf00a6f"
 MPICH_jll = "7cb0a576-ebde-5e09-9194-50597f1243b4"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 ParallelDataTransfer = "2dcacdae-9679-587a-88bb-8b444fb7085b"
@@ -39,9 +40,8 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
-[sources.SlackThreads]
-rev = "main"
-url = "https://github.com/andrew-saydjari/SlackThreads.jl.git"
+[sources]
+SlackThreads = {rev = "main", url = "https://github.com/andrew-saydjari/SlackThreads.jl.git"}
 
 [compat]
 ArgParse = "1"
@@ -64,6 +64,7 @@ Interpolations = "0.14, 0.15"
 JLD2 = "0.4, 0.5, 0.6"
 Jackknife = "0.4.0"
 JuliaFormatter = "1, 2"
+LowRankOps = "0.1.1"
 MPICH_jll = "<4.2.3"
 Optim = "1.10.0"
 ParallelDataTransfer = "0.5"

--- a/scripts/bulk/run_bulk.sh
+++ b/scripts/bulk/run_bulk.sh
@@ -156,6 +156,7 @@ if [ "$run_2d_only" != "true" ]; then
     for tele in ${tele_list[@]}
     do
         print_elapsed_time "Running 2D->1D Pipeline for $tele"
+        mkdir -p ${outdir}/wavecal
         julia +$julia_version --project=$base_dir $base_dir/pipeline_2d_1d.jl --tele $tele --runlist $runlist --outdir $outdir --runname $runname --checkpoint_mode $checkpoint_mode
     done
     # ## Plots

--- a/scripts/bulk/run_bulk.sh
+++ b/scripts/bulk/run_bulk.sh
@@ -10,7 +10,7 @@
 
 # ------------------------------------------------------------------------------
 #SBATCH --partition=cca
-#SBATCH --nodes=8
+#SBATCH --nodes=4
 #SBATCH --constraint="[genoa|icelake|rome]"
 
 #SBATCH --time=4-00:00

--- a/scripts/bulk/run_bulk.sh
+++ b/scripts/bulk/run_bulk.sh
@@ -10,7 +10,7 @@
 
 # ------------------------------------------------------------------------------
 #SBATCH --partition=cca
-#SBATCH --nodes=1
+#SBATCH --nodes=8
 #SBATCH --constraint="[genoa|icelake|rome]"
 
 #SBATCH --time=4-00:00

--- a/scripts/bulk/run_bulk.sh
+++ b/scripts/bulk/run_bulk.sh
@@ -10,7 +10,7 @@
 
 # ------------------------------------------------------------------------------
 #SBATCH --partition=cca
-#SBATCH --nodes=4
+#SBATCH --nodes=8
 #SBATCH --constraint="[genoa|icelake|rome]"
 
 #SBATCH --time=4-00:00

--- a/scripts/cal/make_relFlux.jl
+++ b/scripts/cal/make_relFlux.jl
@@ -59,8 +59,7 @@ end
     using JLD2, ProgressMeter, ArgParse, Glob, StatsBase, ParallelDataTransfer
     using HDF5, DataFrames, SlackThreads
     using ApogeeReduction
-    using ApogeeReduction: safe_jldsave, read_almanac_exp_df, get_1d_name, get_relFlux,
-                           read_metadata
+    using ApogeeReduction: safe_jldsave, read_almanac_exp_df, get_1d_name, get_relFlux, read_metadata
 end
 
 @passobj 1 workers() parg # make it available to all workers

--- a/scripts/daily/run_all.sh
+++ b/scripts/daily/run_all.sh
@@ -5,8 +5,8 @@
 # sbatch /mnt/home/asaydjari/gitcode/ApogeeReduction.jl/scripts/daily/run_all.sh apo 60855
 
 # ------------------------------------------------------------------------------
-#SBATCH --partition=preempt
-#SBATCH --qos=preempt
+#SBATCH --partition=cca
+#SBATCH --qos=cca
 #SBATCH --constraint="[genoa|icelake|rome]"
 #SBATCH --nodes=1
 

--- a/scripts/ood/gen_train_cov.jl
+++ b/scripts/ood/gen_train_cov.jl
@@ -1,0 +1,422 @@
+using InteractiveUtils
+versioninfo(); flush(stdout);
+@time "Package activation" begin
+    import Pkg
+    Pkg.instantiate()
+    Pkg.precompile() # no need for Pkg.activate("./") because of invocation w/ environment
+    using Distributed, ArgParse, TimerOutputs
+end
+
+## Parse command line arguments
+function parse_commandline()
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "--tele"
+        required = false
+        help = "telescope name (apo or lco)"
+        arg_type = String
+        default = ""
+        "--outdir"
+        required = true
+        help = "output directory"
+        arg_type = String
+        default = ""
+        "--ood_dir"
+        required = true
+        help = "directory where ood data is stored"
+        arg_type = String
+        default = ""
+        "--runlist"
+        required = true
+        help = "path name to hdf5 file with keys specifying list of exposures to run"
+        arg_type = String
+        default = ""
+        "--runname"
+        required = true
+        help = "name of the run (specifically almanac file)"
+        arg_type = String
+        default = "test"
+    end
+    return parse_args(s)
+end
+
+parg = parse_commandline()
+
+proj_path = dirname(Base.active_project()) * "/"
+include(joinpath(proj_path, "src/makie_plotutils.jl"))
+
+if "SLURM_NTASKS" in keys(ENV)
+    using SlurmClusterManager
+    addprocs(SlurmManager(), exeflags = ["--project=$proj_path"])
+else
+    addprocs(64)
+end
+
+using JLD2
+@everywhere begin
+    using ParallelDataTransfer
+end
+
+@passobj 1 workers() parg # make it available to all workers
+@passobj 1 workers() proj_path
+
+tele_list = if parg["runlist"] != ""
+    load(parg["runlist"], "tele")
+else
+    [parg["tele"]]
+end
+unique_teles = unique(tele_list)
+mskTele = tele_list .== parg["tele"];
+
+mjd_list = if parg["runlist"] != ""
+    load(parg["runlist"], "mjd")
+else
+    [parg["mjd"]]
+end
+unique_mjds = unique(mjd_list[mskTele]);
+
+dfindx_list = if parg["runlist"] != ""
+    load(parg["runlist"], "dfindx")
+else
+    [parg["dfindx"]]
+end;
+
+# predefined choices
+@everywhere begin
+    nsub = 10
+    tpix = 16
+    plot_pdir = parg["ood_dir"]
+end
+
+@everywhere begin
+    exposure_types = ["fpi", "thar", "une"] # dark, internalflat, domeflat, quartzflat
+    function get_1d_name_FPI(expid,df,mjd,outdir)
+        if (df.image_type[expid] == "arclamp") & (df.lamp_thar[expid] == 0) & (df.lamp_une[expid] == 0)
+            return outdir * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *".h5"
+        else
+            return nothing
+        end
+    end
+
+    function get_1d_name_thar(expid,df,mjd,outdir)
+        if (df.image_type[expid] == "arclamp") & (df.lamp_thar[expid] == 1)
+            return outdir * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *".h5"
+        else
+            return nothing
+        end
+    end
+
+    function get_1d_name_une(expid,df,mjd,outdir)
+        if (df.image_type[expid] == "arclamp") & (df.lamp_une[expid] == 1)
+            return outdir * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) *".h5"
+        else
+            return nothing
+        end
+    end
+
+    function get_1d_name_dark(expid,df,mjd,outdir)
+        if (df.image_type[expid] == "dark")
+            return outdir * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) * ".h5"
+        else
+            return nothing
+        end
+    end
+
+    function get_1d_name_domeflat(expid,df,mjd,outdir)
+        if (df.image_type[expid] == "domeflat")
+            return outdir * "/apred/$(mjd)/" * get_1d_name(expid, df, cal = true) * ".h5"
+        else
+            return nothing
+        end
+    end
+    exposure_1dname_functions = [get_1d_name_FPI, get_1d_name_thar, get_1d_name_une] # get_1d_name_dark, get_1d_name_domeflat]
+end
+
+# predefined functions
+@everywhere begin
+    using ApogeeReduction
+    import ApogeeReduction: read_almanac_exp_df, get_1d_name, bad_pix_bits
+    using LowRankOps, LinearAlgebra, StatsBase
+    using HDF5, JLD2, DelimitedFiles, ProgressMeter
+    
+    yranges = []
+    xranges = []
+    for i in 1:4
+        push!(xranges, 128 + 512*(i-1) : 128 + tpix - 1 + 512*(i-1))
+        push!(yranges, 256 + 512*(i-1) : 256 + tpix - 1 + 512*(i-1))
+    end
+
+    function get_testsubimage(fname)
+        f = h5open(fname, "r")
+        dimage = zeros(Float64, (length(xranges[1]), sum(length.(yranges))))
+        pix_bitmask = zeros(Int64,  (length(xranges[1]), sum(length.(yranges))))
+        for i in 1:4
+            dimage[:,(1:tpix) .+ tpix*(i-1)] .= f["dimage"][xranges[i],yranges[i]]
+            pix_bitmask[:,(1:tpix) .+ tpix*(i-1)] .= f["pix_bitmask"][xranges[i],yranges[i]]
+        end
+        mask_good = (pix_bitmask .& bad_pix_bits) .== 0;
+        close(f)
+        return dimage[mask_good], mask_good
+    end
+    
+    function wood_precomp_mult(matList)
+        Ainv = matList[1]
+        V = matList[2]
+        AinvV = Ainv*V
+        return [(AinvV)*inv(I+V'*(AinvV))]
+    end
+
+    function wood_fxn_mult(matList,precompList,x)
+        Ainv = matList[1]
+        V = matList[2]
+        arg1 = precompList[1]
+        return Ainv*(x - V*(arg1'*x))
+    end
+
+    function get_chi2(fname, mat2D_cen, Vmat)
+        f = h5open(fname, "r")
+        dimage = zeros(Float64, (length(xranges[1]), sum(length.(yranges))))
+        ivarimage = zeros(Float64, (length(xranges[1]), sum(length.(yranges))))
+        pix_bitmask = zeros(Int64,  (length(xranges[1]), sum(length.(yranges))))
+        for i in 1:4
+            dimage[:,(1:tpix) .+ tpix*(i-1)] .= f["dimage"][xranges[i],yranges[i]]
+            ivarimage[:,(1:tpix) .+ tpix*(i-1)] .= f["ivarimage"][xranges[i],yranges[i]]
+            pix_bitmask[:,(1:tpix) .+ tpix*(i-1)] .= f["pix_bitmask"][xranges[i],yranges[i]]
+        end
+        close(f)
+        mask_good = (pix_bitmask .& bad_pix_bits) .== 0;
+        dimage_cen = (dimage .- mat2D_cen)[mask_good]
+        npix = count(mask_good)
+        Ainv = Diagonal(ivarimage[mask_good])
+        Vmat_loc = Vmat[mask_good[:],:]
+        Ctotinv = LowRankMultMat([Ainv,Vmat_loc],wood_precomp_mult,wood_fxn_mult);
+        chi2 = dimage_cen'*(Ctotinv*dimage_cen)/npix
+
+        # flux spread metric
+        spread = std(dimage_cen)
+        chi_fluxscatter = (spread - p50_spread)
+        if chi_fluxscatter < 0
+            chi_fluxscatter /= (p50_spread - p16_spread)
+        else
+            chi_fluxscatter /= (p84_spread - p50_spread)
+        end
+        return chi2, chi_fluxscatter
+    end
+end
+
+# need an outer loop over the exposure types
+for (exposure_type, exposure_1dname_function) in zip(exposure_types, exposure_1dname_functions)
+    println("Making bad list for $(exposure_type) exposures"); flush(stdout);
+    for chip in CHIP_LIST
+        println("... on chip $(chip)"); flush(stdout);
+        list1Dexp = []
+        list1Dexp_all = []
+        for mjd in unique_mjds
+            df = read_almanac_exp_df(
+                joinpath(parg["outdir"], "almanac/$(parg["runname"]).h5"), parg["tele"], mjd)
+            exposure_1dname_function_partial(expid) = exposure_1dname_function(expid, df, mjd, parg["outdir"]);
+            if any(df.image_type .== "object")
+                mskMJD = (mjd_list .== mjd) .& mskTele
+                local1D = exposure_1dname_function_partial.(dfindx_list[mskMJD])
+                push!(list1Dexp, filter(!isnothing, local1D))
+                push!(list1Dexp_all, filter(!isnothing, local1D))
+            else
+                mskMJD = (mjd_list .== mjd) .& mskTele
+                local1D = exposure_1dname_function_partial.(dfindx_list[mskMJD])
+                push!(list1Dexp_all, filter(!isnothing, local1D))
+            end
+        end
+
+        train1Dfiles = convert(Vector{String}, vcat(list1Dexp...));
+        train2Dfiles = replace.(train1Dfiles, "ar1Dcal" => "ar2Dcal");
+        all1Dfiles = convert(Vector{String}, vcat(list1Dexp_all...));
+        all2Dfiles = replace.(all1Dfiles, "ar1Dcal" => "ar2Dcal");
+
+        oodfname = "$(exposure_type)_roughprior_$(chip)_$(nsub).h5"
+
+        mat2D = zeros(length(xranges[1]), sum(length.(yranges)),length(train2Dfiles));
+        cnt2D = zeros(length(xranges[1]), sum(length.(yranges)),length(train2Dfiles));
+        
+        pout = @showprogress pmap(get_testsubimage, train2Dfiles)
+        
+        for (i,(dimage,mask_good)) in enumerate(pout)
+            mat2D[mask_good,i] .= dimage
+            cnt2D[mask_good,i] .+= 1
+        end
+
+        # rough mask based on flux scatter
+        spread_vec = dropdims(std(mat2D, dims=(1,2)), dims=(1,2))
+        p16_spread, p50_spread, p84_spread = percentile(spread_vec, [16, 50, 84])
+        chi_fluxscatter = (spread_vec.-p50_spread)
+        msk_neg = (chi_fluxscatter .< 0)
+        msk_pos = (chi_fluxscatter .> 0)
+        chi_fluxscatter[msk_neg] ./= (p50_spread.-p16_spread)
+        chi_fluxscatter[msk_pos] ./= (p84_spread.-p50_spread)
+
+        # this seems to work fine for fpi, arclamps, darks
+        # struggles with domeflats (TODO)
+        msk_indist = -2.5 .< chi_fluxscatter .< 30;
+
+        # get centers of distribution
+        mat2D_cnt = dropdims(sum(cnt2D[:,:,msk_indist],dims=3),dims=3)
+        mat2D_cen = dropdims(sum(mat2D[:,:,msk_indist],dims=3),dims=3)./(mat2D_cnt .+ (mat2D_cnt.==0));
+        mat2Dvec = reshape(mat2D,:,length(train2Dfiles))[:,msk_indist]
+        mat2Dvec_cnt = reshape(cnt2D,:,length(train2Dfiles))[:,msk_indist];
+        mat2Dvec_cen = reshape(mat2D_cen,:);
+
+        # build covariance matrix
+        Covprior = (mat2Dvec .- mat2Dvec_cen) * (mat2Dvec .- mat2Dvec_cen)'
+        norm_weights = (mat2Dvec_cnt * mat2Dvec_cnt')
+        Covprior ./= (norm_weights .+ (norm_weights.==0));
+
+        # SVD for low-rank approximation
+        SF = svd(Covprior);
+        EVEC = zeros(size(mat2Dvec,1),size(SF.U,2))
+        EVEC.=SF.U;
+        Vmat = EVEC[:,1:nsub]*Diagonal(sqrt.(SF.S[1:nsub]));
+
+        # save results
+        h5write(oodfname, "Vmat", Vmat)
+        h5write(oodfname, "mat2D_cen", mat2D_cen);
+        h5write(oodfname, "p16_spread", p16_spread);
+        h5write(oodfname, "p50_spread", p50_spread);
+        h5write(oodfname, "p84_spread", p84_spread);
+
+        @everywhere begin
+            Vmat = load($oodfname, "Vmat")
+            mat2D_cen = load($oodfname, "mat2D_cen")
+            p16_spread = load($oodfname, "p16_spread")
+            p50_spread = load($oodfname, "p50_spread")
+            p84_spread = load($oodfname, "p84_spread")
+        end
+
+        @everywhere get_chi2_partial(fname) = get_chi2(fname, mat2D_cen, Vmat);
+        pout = @showprogress pmap(get_chi2_partial, all2Dfiles);
+        chi2out = zeros(length(all2Dfiles));
+        chifluxscatterout = zeros(length(all2Dfiles));
+        for (i,(chi2, chi_fluxscatter)) in enumerate(pout)
+            chi2out[i] = chi2
+            chifluxscatterout[i] = chi_fluxscatter
+        end
+        pchi2 = sortperm(chi2out,rev=true);
+        pscatter = sortperm(chifluxscatterout,rev=true);
+        msk_good_chifluxscatter = (-2.5 .< chifluxscatterout .< 30);
+        msk_good_chi2 = (0.3 .< chi2out .< 10);
+        msk_good = msk_good_chifluxscatter .& msk_good_chi2;
+        msk_bad = .!msk_good;
+
+        # need to save
+        bad_fname = "$(exposure_type)_$(chip)_bad.csv"
+        # need tele, mjd, expid, chip
+        tele_vec = map(x->split(basename(x), "_")[2], all2Dfiles[msk_bad]);
+        mjd_vec = map(x->parse(Int, split(basename(x), "_")[3]), all2Dfiles[msk_bad]);
+        expid_vec = map(x->parse(Int, split(basename(x), "_")[4]), all2Dfiles[msk_bad]);
+        chip_vec = map(x->split(basename(x), "_")[5], all2Dfiles[msk_bad]);
+        writedlm(bad_fname, hcat(tele_vec, mjd_vec, expid_vec, chip_vec));
+
+        # need to do plots
+        badinds = findall(msk_bad);
+        just_goodinds = []
+
+        # Helper to compute safe ranges
+        function safe_range(start, stop, n)
+            # Clamp range to [1, n] and handle possible negatives/missing
+            start = max(1, min(n, start))
+            stop = max(1, min(n, stop))
+            if start > stop
+                Int[]
+            else
+                collect(start:stop)
+            end
+        end
+
+        # Just_goodinds block, robust to bounds
+        npscatter = length(pscatter)
+        npchi2 = length(pchi2)
+
+        fst_indx = findfirst(chifluxscatterout[pscatter] .< 30)
+        if !isnothing(fst_indx)
+            inds = safe_range(fst_indx, min(fst_indx+4, npscatter), npscatter)
+            push!(just_goodinds, pscatter[inds])
+        end
+
+        fst_indx = findlast(-2.5 .< chifluxscatterout[pscatter])
+        if !isnothing(fst_indx)
+            start_idx = fst_indx+1
+            inds = safe_range(start_idx, min(start_idx+4, npscatter), npscatter)
+            if !isempty(inds)
+                push!(just_goodinds, pscatter[inds])
+            end
+        end
+
+        fst_indx = findfirst(chi2out[pchi2] .< 10)
+        if !isnothing(fst_indx)
+            inds = safe_range(fst_indx, min(fst_indx+4, npchi2), npchi2)
+            push!(just_goodinds, pchi2[inds])
+        end
+
+        fst_indx = findlast(chi2out[pchi2] .< 10)
+        if !isnothing(fst_indx)
+            start_idx = fst_indx+1
+            inds = safe_range(start_idx, min(start_idx+4, npchi2), npchi2)
+            if !isempty(inds)
+                push!(just_goodinds, pchi2[inds])
+            end
+        end
+
+        just_goodinds = unique(vcat(just_goodinds...));
+
+        center_indx = pchi2[length(pchi2)÷2]
+        center_fname = all2Dfiles[center_indx];
+        center_dimage = load(center_fname, "dimage")
+        center_pix_bitmask = load(center_fname, "pix_bitmask")
+        center_mask_good = (center_pix_bitmask .& bad_pix_bits) .== 0;
+        center_dimage[.!(center_mask_good)] .= NaN
+        vmin, vmax = percentile(center_dimage[center_mask_good], [1, 99])
+
+        for (ind_list, class_name) in zip([just_goodinds, badinds], ["just_good", "bad"])
+            plot_dir = joinpath(plot_pdir, "$(exposure_type)_$(chip)_$(class_name)");
+            mkpath(plot_dir);
+            for indx in ind_list
+                fname = all2Dfiles[indx];
+                dimage = load(fname, "dimage");
+                pix_bitmask = load(fname, "pix_bitmask")
+                mask_good = (pix_bitmask .& bad_pix_bits) .== 0;
+                dimage[.!(mask_good)] .= NaN
+
+                fig = Figure(size=(800,800),fontsize=30)
+                ax = Axis(fig[1,1], title="$(class_name): $(basename(fname))\nChi2: $(round(chi2out[indx], digits=2)) $(msk_good_chi2[indx] ? "Pass" : "Fail"), ChiFluxScatter: $(round(chifluxscatterout[indx], digits=2)) $(msk_good_chifluxscatter[indx] ? "Pass" : "Fail")")
+                hm = heatmap!(ax, dimage,
+                    colormap=ColorSchemes.cmr_chroma,
+                    colorrange=(vmin, vmax),
+                    nan_color=(93/300, 101/300, 106/300))
+
+                ax = Axis(fig[2,1],)
+                hm = heatmap!(ax, center_dimage,
+                    colormap=ColorSchemes.cmr_chroma,
+                    colorrange=(vmin, vmax),
+                    nan_color=(93/300, 101/300, 106/300))
+                data_aspect = size(center_dimage,1) / size(center_dimage,2)
+                colsize!(fig.layout, 1, Aspect(1, data_aspect))
+
+                ax = Axis(fig[1,2],)
+                hm = heatmap!(ax, dimage[1024:1536,1024:1536],
+                    colormap=ColorSchemes.cmr_chroma,
+                    colorrange=(vmin, vmax),
+                    nan_color=(93/300, 101/300, 106/300))
+
+                ax = Axis(fig[2,2],)
+                hm = heatmap!(ax, center_dimage[1024:1536,1024:1536],
+                    colormap=ColorSchemes.cmr_chroma,
+                    colorrange=(vmin, vmax),
+                    nan_color=(93/300, 101/300, 106/300))
+                data_aspect = size(center_dimage[1024:1536,1024:1536],1) / size(center_dimage[1024:1536,1024:1536],2)
+                colsize!(fig.layout, 2, Aspect(1, data_aspect))
+                
+                Colorbar(fig[1:2, 3], hm, width = 10, height = Relative(1.0))
+                resize_to_layout!(fig)
+                save(joinpath(plot_dir, "$(basename(fname))_$(class_name).png"), fig)
+            end
+        end
+    end
+end

--- a/scripts/ood/run_ood.sh
+++ b/scripts/ood/run_ood.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#SBATCH --partition=cca,gen,genx
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --mem=0 #requesting all of the memory on the node
+
+#SBATCH --time=8:00:00
+#SBATCH --job-name=ar_ood
+#SBATCH --output=slurm_logs/%x_%j.out
+# ------------------------------------------------------------------------------
+set -e # exit immediately if any of the steps returns a non-zero exit code
+set -o pipefail
+
+if [ -n "$SLURM_JOB_NODELIST" ]; then
+    hostname
+    echo $SLURM_JOB_NODELIST
+else
+    hostname
+fi
+echo "running from $(pwd)"
+
+if [ -n "${SLURM_JOB_ID:-}" ] ; then
+    script_path=$(scontrol show job "$SLURM_JOB_ID" | awk -F= '/Command=/{print $2}')
+else
+    script_path=$(realpath "$0")
+fi
+base_dir="$(dirname "$(dirname "$(dirname "$script_path")")")"
+echo "base_dir: $base_dir"
+
+julia_version="1.11.6"
+juliaup add $julia_version
+
+# hardcode the mjd and expid for now
+outdir=$1
+mjd_start=$2
+mjd_end=$3
+
+ood_dir="ood/"
+runname="allobs_${mjd_start}_${mjd_end}"
+almanac_file=${outdir}almanac/${runname}.h5
+runlist=${outdir}almanac/runlist_${runname}.h5
+tele_list=("apo" "lco")
+
+# nice function to print the elapsed time at each step
+print_elapsed_time() {
+    formatted_time=$(printf '%dd %dh:%dm:%ds\n' $(($SECONDS/86400)) $(($SECONDS%86400/3600)) $(($SECONDS%3600/60)) $(($SECONDS%60)))
+    echo
+    echo "Elapsed time: $formatted_time"
+    echo
+    echo "--------- $1 ---------"
+    echo
+}
+
+# make the ood exposure lists
+print_elapsed_time "Making OOD Exposure Lists"
+for tele in ${tele_list[@]}
+do
+    julia +$julia_version --project=$base_dir $base_dir/scripts/ood/gen_train_cov.jl --tele $tele --ood_dir $ood_dir --outdir $outdir --runlist $runlist --runname $runname
+done
+
+
+# Clean up logs and Report Timing
+print_elapsed_time "Job completed"

--- a/src/wavecal.jl
+++ b/src/wavecal.jl
@@ -1704,14 +1704,29 @@ function skyline_medwavecal_skyline_dither(tele, mjd, mjd_list_wavecal, all1DObj
             plot_pixels = (1, 512, 1024, 1536, 2048))
 
 	    curr_wave_type = "sky"
-        h5open(outname, "w") do f
-            #should include metadata at some point...
-            f["best_wave_type"] = curr_wave_type
-            f["$(curr_wave_type)/used_fnames"] = all1DObjectWavecal_mjd
-            f["$(curr_wave_type)/nightAve_wave_soln"] = night_wave_soln
-            f["$(curr_wave_type)/nightAve_nlParams"] = night_nlParams
-            f["$(curr_wave_type)/nightAve_linParams"] = night_linParams
-        end	
+
+	# REMOVE TRY/CATCH LATER. Just testing for bulk run to figure out failure
+	try
+            h5open(outname, "w") do f
+                #should include metadata at some point...
+                f["best_wave_type"] = curr_wave_type
+                f["$(curr_wave_type)/used_fnames"] = all1DObjectWavecal_mjd
+                f["$(curr_wave_type)/nightAve_wave_soln"] = night_wave_soln
+                f["$(curr_wave_type)/nightAve_nlParams"] = night_nlParams
+                f["$(curr_wave_type)/nightAve_linParams"] = night_linParams
+            end	
+	catch
+	    #can either fail loudly after printing info, or just skip...
+	    println("Failed to open $(outname) in skyline_medwavecal_skyline_dither for $(tele) $(mjd). Previous file exists? $(isfile(outname))")
+            h5open(outname, "w") do f
+                #should include metadata at some point...
+                f["best_wave_type"] = curr_wave_type
+                f["$(curr_wave_type)/used_fnames"] = all1DObjectWavecal_mjd
+                f["$(curr_wave_type)/nightAve_wave_soln"] = night_wave_soln
+                f["$(curr_wave_type)/nightAve_nlParams"] = night_nlParams
+                f["$(curr_wave_type)/nightAve_linParams"] = night_linParams
+            end	
+	end
 
         return outname
     else

--- a/src/wavecal.jl
+++ b/src/wavecal.jl
@@ -1703,30 +1703,16 @@ function skyline_medwavecal_skyline_dither(tele, mjd, mjd_list_wavecal, all1DObj
             plot_fibers = (1, 50, 100, 150, 200, 250, 300),
             plot_pixels = (1, 512, 1024, 1536, 2048))
 
-	    curr_wave_type = "sky"
+        curr_wave_type = "sky"
 
-	# REMOVE TRY/CATCH LATER. Just testing for bulk run to figure out failure
-	try
-            h5open(outname, "w") do f
-                #should include metadata at some point...
-                f["best_wave_type"] = curr_wave_type
-                f["$(curr_wave_type)/used_fnames"] = all1DObjectWavecal_mjd
-                f["$(curr_wave_type)/nightAve_wave_soln"] = night_wave_soln
-                f["$(curr_wave_type)/nightAve_nlParams"] = night_nlParams
-                f["$(curr_wave_type)/nightAve_linParams"] = night_linParams
-            end	
-	catch
-	    #can either fail loudly after printing info, or just skip...
-	    println("Failed to open $(outname) in skyline_medwavecal_skyline_dither for $(tele) $(mjd). Previous file exists? $(isfile(outname))")
-            h5open(outname, "w") do f
-                #should include metadata at some point...
-                f["best_wave_type"] = curr_wave_type
-                f["$(curr_wave_type)/used_fnames"] = all1DObjectWavecal_mjd
-                f["$(curr_wave_type)/nightAve_wave_soln"] = night_wave_soln
-                f["$(curr_wave_type)/nightAve_nlParams"] = night_nlParams
-                f["$(curr_wave_type)/nightAve_linParams"] = night_linParams
-            end	
-	end
+        h5open(outname, "w") do f
+            #should include metadata at some point...
+            f["best_wave_type"] = curr_wave_type
+            f["$(curr_wave_type)/used_fnames"] = all1DObjectWavecal_mjd
+            f["$(curr_wave_type)/nightAve_wave_soln"] = night_wave_soln
+            f["$(curr_wave_type)/nightAve_nlParams"] = night_nlParams
+            f["$(curr_wave_type)/nightAve_linParams"] = night_linParams
+        end	
 
         return outname
     else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an out-of-distribution (OOD) prep workflow and scales batch processing, alongside environment updates.
> 
> - **New OOD tooling**: `scripts/ood/gen_train_cov.jl` builds low-rank covariance priors with `LowRankOps`, scores exposures (chi²/flux scatter), writes bad lists, and generates diagnostic plots; `scripts/ood/run_ood.sh` orchestrates runs per telescope
> - **Batch/Daily job updates**: `scripts/bulk/run_bulk.sh` now requests `--nodes=8` and ensures `mkdir -p ${outdir}/wavecal` before 2D→1D; `scripts/daily/run_all.sh` switches to `partition/qos=cca`
> - **RelFlux minor cleanup**: streamlined imports; unchanged behavior
> - **Wavecal**: small cleanup of `curr_wave_type` assignment; ensures plot directory exists
> - **Env/deps**: Manifest updates including `julia 1.11.6`, `ColorSchemes` bump; add `LowRankOps` to `Project.toml` with compat; normalize `[sources]` block
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adf3273987867000b2e20e1b2587ae5ae78a6c1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->