### PR TITLE
[WIP] Update almanac HDF5 access to use raw/ top-level group

### DIFF
--- a/scripts/bulk/make_runlist_all.jl
+++ b/scripts/bulk/make_runlist_all.jl
@@ -36,20 +36,20 @@ dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
 tele2do = if parg["tele"] == "both"
-    keys(f)
+    keys(f["raw"])
 else
     [parg["tele"]]
 end
 
 # Check if almanac file is empty and exit with specific code
-if length(keys(f)) == 0
+if !haskey(f, "raw") || length(keys(f["raw"])) == 0
     println("WARNING: No exposures found for the specified parameters")
     println("Exiting with code 16 to indicate empty runlist")
     exit(16)
 end
 
 for tele in tele2do
-    mjd_list = keys(f[tele])
+    mjd_list = keys(f["raw/$(tele)"])
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)

--- a/scripts/cal/make_runlist_darks.jl
+++ b/scripts/cal/make_runlist_darks.jl
@@ -34,12 +34,12 @@ dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
 tele2do = if parg["tele"] == "both"
-    keys(f)
+    keys(f["raw"])
 else
     [parg["tele"]]
 end
 for tele in tele2do
-    mjd_list = keys(f[tele])
+    mjd_list = keys(f["raw/$(tele)"])
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)

--- a/scripts/cal/make_runlist_fiber_flats.jl
+++ b/scripts/cal/make_runlist_fiber_flats.jl
@@ -39,12 +39,12 @@ dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
 tele2do = if parg["tele"] == "both"
-    keys(f)
+    keys(f["raw"])
 else
     [parg["tele"]]
 end
 for tele in tele2do
-    mjd_list = keys(f[tele])
+    mjd_list = keys(f["raw/$(tele)"])
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)

--- a/scripts/cal/make_runlist_internal_flats.jl
+++ b/scripts/cal/make_runlist_internal_flats.jl
@@ -34,12 +34,12 @@ dfindx_list = Int[]
 tele_list = String[]
 f = h5open(parg["almanac_file"])
 tele2do = if parg["tele"] == "both"
-    keys(f)
+    keys(f["raw"])
 else
     [parg["tele"]]
 end
 for tele in tele2do
-    mjd_list = keys(f[tele])
+    mjd_list = keys(f["raw/$(tele)"])
     for tstmjd in mjd_list
         tstmjd_int = parse(Int, tstmjd)
         df = read_almanac_exp_df(f, tele, tstmjd)

--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -347,7 +347,7 @@ function get_fibTargDict(f, tele, mjd, dfindx)
             (Dict(1:300 .=> "fiberTypeFail"), Dict(1:300 .=> -2))
         else
             try
-                df_fib = DataFrame(read(f["$(tele)/$(mjd)/fibers/$(config_id)"]))
+                df_fib = DataFrame(read(f["raw/$(tele)/$(mjd)/fibers/$(config_id)"]))
                 # normalizes all column names to lowercase
                 rename!(df_fib, lowercase.(names(df_fib)))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -378,10 +378,10 @@ end
 
 function read_almanac_exp_df(fname, tele, mjd)
     df = if fname isa HDF5.File
-        DataFrame(read(fname["$(tele)/$(mjd)/exposures"]))
+        DataFrame(read(fname["raw/$(tele)/$(mjd)/exposures"]))
     else
         h5open(fname) do f
-            DataFrame(read(f["$(tele)/$(mjd)/exposures"]))
+            DataFrame(read(f["raw/$(tele)/$(mjd)/exposures"]))
         end
     end
     return df

--- a/src/wavecal.jl
+++ b/src/wavecal.jl
@@ -1675,6 +1675,7 @@ function skyline_medwavecal_skyline_dither(tele, mjd, mjd_list_wavecal, all1DObj
 
     outname = joinpath(
         outdir, "wavecal", "wavecalNightAve_$(tele)_$(mjd).h5")
+    mkpath(dirname(outname))
     
     if check_file(outname, mode = checkpoint_mode)
         #then skip making new file


### PR DESCRIPTION
Adapts to new almanac file structure where observatory groups (apo, lco) are nested under a 'raw' top-level group.

Changes:
- src/utils.jl: read_almanac_exp_df now accesses raw/{tele}/{mjd}/exposures
- src/ar1D.jl: get_fibTargDict now accesses raw/{tele}/{mjd}/fibers/{config_id}
- scripts/bulk/make_runlist_all.jl: Updated to iterate over keys(f["raw"])
- scripts/cal/make_runlist_*.jl: Updated to use raw/{tele} paths

This corresponds to changes in andycasey/almanac PR #42.