### PR TITLE
Don't relFlux broken fibers; propagate bitmsk_relthrpt to ar1Dunical

### DIFF
--- a/src/ar1D.jl
+++ b/src/ar1D.jl
@@ -520,6 +520,7 @@ function reinterp_spectra(fname, roughwave_dict; checkpoint_mode = "commit_same"
     chipInt_stack = zeros(N_CHIPS * N_XPIX, N_FIBERS)
     chipBit_stack = zeros(Int, N_CHIPS * N_XPIX, N_FIBERS)
     thrpt_stack = zeros(N_CHIPS, N_FIBERS)
+    bitmsk_thrpt_stack = zeros(Int, N_CHIPS, N_FIBERS)
 
     ingestBit = zeros(Int, N_FIBERS)
 
@@ -592,6 +593,7 @@ function reinterp_spectra(fname, roughwave_dict; checkpoint_mode = "commit_same"
         dropped_pixels_mask_1d = f["dropped_pixels_mask_1d"]
         extract_trace_centers = f["extract_trace_centers"]
         relthrpt = f["relthrpt"]
+        bitmsk_relthrpt = f["bitmsk_relthrpt"]
         close(f)
         push!(metadata_lst, read_metadata(fnameloc))
 
@@ -611,6 +613,7 @@ function reinterp_spectra(fname, roughwave_dict; checkpoint_mode = "commit_same"
         chipBit_stack[(1:N_XPIX) .+ (3 - chipind) * N_XPIX, :] .+= 2^(chipind)
         chipInt_stack[(1:N_XPIX) .+ (3 - chipind) * N_XPIX, :] .= chipind
         thrpt_stack[chipind, :] .= relthrpt
+        bitmsk_thrpt_stack[chipind, :] .= bitmsk_relthrpt
     end
 
     # should add a check all entries of metadata_lst to be equal
@@ -694,7 +697,8 @@ function reinterp_spectra(fname, roughwave_dict; checkpoint_mode = "commit_same"
     # Write reinterpolated data
     safe_jldsave(
         outname, metadata; flux_1d = outflux, ivar_1d = outivar, mask_1d = outmsk,
-        extract_trace_coords = outTraceCoords, relthrpt = thrpt_stack)
+        extract_trace_coords = outTraceCoords, relthrpt = thrpt_stack,
+        bitmsk_relthrpt = bitmsk_thrpt_stack)
     return
 end
 
@@ -802,7 +806,11 @@ function process_1D(fname;
         end
 
         # don't flux broken fibers (don't use warn fibers for sky)
-        msk_goodwarn = (bitmsk_relthrpt .== 0) .| (bitmsk_relthrpt .& 2^0) .== 2^0
+        # broken fibers (bit 1, relthrpt < rel_val_cut) always also have the low-throughput
+        # warn bit 0 set, so the mask must exclude on bit 1 explicitly: their relthrpt is a
+        # noise-level (possibly negative) domeflat measurement and dividing by it produces
+        # arbitrarily inflated flux. Bit 2 (no fluxing file) is excluded as before.
+        msk_goodwarn = (bitmsk_relthrpt .& (2^1 | 2^2)) .== 0
         if any(msk_goodwarn)
             flux_1d[:, msk_goodwarn] ./= relthrptr[:, msk_goodwarn]
             ivar_1d[:, msk_goodwarn] .*= relthrptr[:, msk_goodwarn] .^ 2


### PR DESCRIPTION
## Bug

The `msk_goodwarn` mask in `process_1D` was intended to skip relative fluxing for broken fibers (`bitmsk_relthrpt` bit 1, `relthrpt < rel_val_cut = 0.07`), but any fiber below `rel_val_cut` is necessarily also far below the IQR-based warn threshold, so every broken fiber carries bit 0 too (`bitmsk = 3`) — and the old expression admitted any fiber with bit 0 set. The broken-fiber exclusion therefore never fired: science flux on broken fibers was divided by a noise-level (sometimes even negative) domeflat throughput measurement, inflating flux by factors up to ~1e4–1e5.

Concrete examples (found while running down extreme-SNR outliers in the 0.2.0 scifest summary; all verified against the 2026_05_01 reduction):
- fiber_id 211 (adjfib 90) at APO is dead (relthrpt ~0.008). Domeflat measurements of it scattered to 1.4e-4 (MJD 58588), 1.6e-5 (58577), 1.9e-4 (58853) — dividing by these produced 0.2.0 visit SNRs of 4e6–6e8 for stars whose true SNR is ~5.
- adjfib 165 on 58011: measured relthrpt was *negative* (-4.4e-5).
- adjfib 226 on 58769: a healthy fiber (~1.0) with a single glitched domeflat measurement of 8.5e-5.

This one mechanism explains the entire top-50 extreme-SNR outlier list in the 0.2.0 summary. (QA figures attached below.)

## Fix

- `msk_goodwarn = (bitmsk_relthrpt .& (2^1 | 2^2)) .== 0` — exclude broken fibers (bit 1) and missing-fluxing-file cases (bit 2) explicitly. Truth-table verified vs the old expression: good (0) and warn-only (1) fibers are fluxed exactly as before; only bitmsk 3 (and the unreachable 5/7) change behavior.
- `reinterp_spectra` now stacks `bitmsk_relthrpt` per chip (3×300, alongside the existing `relthrpt` stack) and saves it in the `ar1Dunical` output, so the broken/warn/no-file flags survive to the end of the exposure pipeline and downstream consumers can cut on them.

Both `reinterp_spectra` call sites are inside the `if parg["relFlux"]` block and `process_1D` writes with the same flag, so the new unconditional `f["bitmsk_relthrpt"]` read has identical exposure to the pre-existing `f["relthrpt"]` read.

## Out of scope (noted for the record)

- A glitched domeflat measurement above `rel_val_cut` (e.g. 0.2 on a healthy fiber) would still be divided in — bounded inflation ≤ 1/0.07 ≈ 14x. Robustifying against that needs cross-domeflat consistency or a night-median throughput.
- Fluxing still uses the B chip only (existing TODO).
- Exporting the flag as a column in the exposures.h5 summary (arMADGICS side) — deferred to the planned rework of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## QA figures (Case study: sdss_id 57884925, apo 58588 exps 22–29, fiber_id 211 / adjfib 90)

**Throughput story** — adjfib 90 per domeflat across the night (B chip dips to 1.4e-4 at domeflat 0030, used by exps 22–29) and relthrpt vs fiber for domeflat 0030 (all broken fibers sit far below the 0.07 cut):
![relthrpt_night](https://raw.githubusercontent.com/andrew-saydjari/ApogeeReduction.jl/qa-assets-pr363/relthrpt_night.png)

**The scale jump** — 0.2.0 SNR ~5e6 for exps 22–29; new-run SNR proxy is flat/correct, but median flux on the broken fiber jumps ~80x exactly between domeflats 19 and 30:
![snr_flux_compare](https://raw.githubusercontent.com/andrew-saydjari/ApogeeReduction.jl/qa-assets-pr363/snr_flux_compare.png)

**0.2.0 "spectra" of the outlier visit are amplified noise** (top) vs normal faint-star control visits (bottom):
![spectra_0p2](https://raw.githubusercontent.com/andrew-saydjari/ApogeeReduction.jl/qa-assets-pr363/spectra_0p2.png)

**New-run flux** — exp 22 (divided by 1.4e-4) vs exp 33 (divided by 6e-3), healthy neighbor unchanged:
![spectra_newrun](https://raw.githubusercontent.com/andrew-saydjari/ApogeeReduction.jl/qa-assets-pr363/spectra_newrun.png)

**Full 0.2.0 SNR history of the star** — only the 58588 visit (the only one that landed on fiber_id 211) is anomalous:
![snr_timeseries](https://raw.githubusercontent.com/andrew-saydjari/ApogeeReduction.jl/qa-assets-pr363/snr_timeseries.png)

**Trace/extraction sanity check** — trace registration is fine; the broken fiber is dark on sky (flat cross-sections at its trace center):
![trace2d](https://raw.githubusercontent.com/andrew-saydjari/ApogeeReduction.jl/qa-assets-pr363/trace2d_apo_58588_0022.png)

*(Images live on the `qa-assets-pr363` branch; delete it after merge if desired — the embeds will break but the record stands in text.)*
